### PR TITLE
Add dev tooling scaffold (ruff, mypy, pytest, pre-commit)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,10 +1,41 @@
 name: Python application
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
+  lint:
+    name: Lint & offline tests
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install ruff==0.15.8 mypy==1.19.1 pytest==9.0.3 types-requests
+
+    - name: Ruff check
+      run: ruff check .
+
+    - name: Ruff format check
+      run: ruff format --check .
+
+    - name: Mypy
+      run: mypy antenati.py antenati_gui.py
+
+    - name: Pytest (offline only)
+      run: pytest -m "not integration"
+
   test:
-    name: Test
+    name: Live download
+    needs: lint
 
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Run on every commit:
+#   pre-commit install
+# To run manually against the whole repo:
+#   pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        files: ^(antenati|antenati_gui)\.py$
+        additional_dependencies:
+          - types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,57 @@
+# NOTE: This is a tooling-only pyproject.toml. The [project] table will be
+# added in a later step together with the move to a src/ layout and the
+# switch to hatchling + hatch-vcs for dynamic versioning. For now, the
+# package is still distributed as standalone scripts and PyInstaller
+# binaries, so we only configure dev tools here.
+
+[tool.ruff]
+line-length = 160
+target-version = "py39"
+extend-exclude = ["build", "dist"]
+
+[tool.ruff.lint]
+# Conservative starting set: enabled rules already pass on the current
+# codebase. Stricter rules (PTH, ANN, D, etc.) will be turned on as the
+# refactor lands and the affected code is rewritten.
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF", "RET", "TID"]
+ignore = [
+    # Allow `Optional[...]` / `Union[...]` while still on Python 3.9.
+    "UP007",
+    "UP045",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Legacy single-file modules: relax style-only rules until they are split
+# into the new package layout in the refactor PRs. Real lint issues are
+# still enforced.
+"antenati.py" = ["UP034", "SIM108", "RET504"]
+"antenati_gui.py" = ["I001"]
+
+[tool.ruff.format]
+quote-style = "single"
+# Legacy single-file modules will be reformatted in a dedicated PR once
+# they are split into the new package layout, to keep the diff for each
+# refactor PR readable.
+exclude = ["antenati.py", "antenati_gui.py"]
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true
+warn_redundant_casts = true
+warn_unreachable = true
+check_untyped_defs = true
+
+# Legacy single-file modules: keep mypy importing them without enforcing
+# strict checks until they are split into the new package layout. Strict
+# mode will then be enabled module-by-module in the refactor PRs.
+[[tool.mypy.overrides]]
+module = ["antenati", "antenati_gui"]
+ignore_errors = true
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"
+markers = [
+    "integration: tests that hit the live Portale Antenati (opt-in, slow, may flake)",
+]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,17 @@
+"""Smoke tests: verify the module can be imported and exposes its public API.
+
+This is the seed of the offline test suite. As the refactor extracts pure
+modules (iiif, http, paths, downloader, ...), per-module unit tests will be
+added next to this file. Live-download tests live under tests/integration/
+behind the `integration` marker.
+"""
+
+import antenati
+
+
+def test_module_imports() -> None:
+    assert antenati.__version__
+    assert antenati.AntenatiDownloader is not None
+    assert antenati.ProgressBar is not None
+    assert antenati.DEFAULT_SIZE == 0
+    assert antenati.DEFAULT_N_THREADS == 2


### PR DESCRIPTION
First step of the refactor planned for v6: introduce the development toolchain without touching production code. Adds:

- pyproject.toml with ruff/mypy/pytest config tuned for the current single-file layout. Strict rules are gated per-file so the existing antenati.py/antenati_gui.py keep passing; they will be enabled module by module as the refactor extracts pure modules under src/antenati/.
- .pre-commit-config.yaml wiring ruff, ruff-format and mypy.
- tests/ directory with an initial smoke test. Live-download tests will live under tests/integration/ behind the `integration` pytest marker.
- A new `lint` job in pythonapp.yml running ruff, ruff-format, mypy and the offline pytest suite on every push and PR. The existing live download job still runs, gated on `lint` succeeding first.