### PR TITLE
Add offline test safety net before refactor

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -18,8 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install ruff==0.15.8 mypy==1.19.1 pytest==9.0.3 types-requests
+        pip install -r requirements.txt -r requirements-dev.txt
 
     - name: Ruff check
       run: ruff check .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Development dependencies. Runtime deps live in requirements.txt.
+# Install with:
+#   pip install -r requirements.txt -r requirements-dev.txt
+ruff==0.15.8
+mypy==1.19.1
+pytest==9.0.3
+responses==0.25.8
+types-requests
+pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+"""Shared test fixtures.
+
+The HTML and IIIF JSON fixtures under ``tests/fixtures/`` mirror the shape
+of the responses served by the real Portale Antenati but contain no real
+data. They let us exercise the parsing, URL manipulation and download
+orchestration of ``AntenatiDownloader`` entirely offline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import responses as responses_module
+
+import antenati
+
+FIXTURES_DIR = Path(__file__).parent / 'fixtures'
+
+# A real-shaped gallery URL: ``__get_archive_id`` extracts the second
+# integer it finds, so we must keep at least two numbers in the path.
+GALLERY_URL = 'https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/gallery'
+ARCHIVE_ID = '19944535'
+
+# The HTML fixture embeds this exact manifest URL inside a ``manifestId``
+# JavaScript assignment.
+MANIFEST_URL = 'https://iiif.example.org/ark/12657/iiif-19944535/manifest'
+
+# Tests don't decode the downloaded payload; any byte sequence is fine.
+TINY_JPEG = b'\xff\xd8\xff\xd9'  # SOI + EOI (smallest "valid" JPEG)
+
+
+@pytest.fixture
+def gallery_html() -> str:
+    return (FIXTURES_DIR / 'gallery.html').read_text(encoding='utf-8')
+
+
+@pytest.fixture
+def manifest_dict() -> dict:
+    with (FIXTURES_DIR / 'manifest_minimal.json').open(encoding='utf-8') as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def manifest_text(manifest_dict: dict) -> str:
+    return json.dumps(manifest_dict)
+
+
+@pytest.fixture
+def mocked_http(gallery_html: str, manifest_text: str):
+    """Register HTTP mocks for the gallery page and the IIIF manifest.
+
+    Image URLs are not registered here: each test adds the canvases it
+    actually exercises so failures are easy to attribute.
+    """
+    with responses_module.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(
+            responses_module.GET,
+            GALLERY_URL,
+            body=gallery_html,
+            status=200,
+            content_type='text/html; charset=utf-8',
+        )
+        rsps.add(
+            responses_module.GET,
+            MANIFEST_URL,
+            body=manifest_text,
+            status=200,
+            content_type='application/json; charset=utf-8',
+        )
+        yield rsps
+
+
+@pytest.fixture
+def downloader(mocked_http) -> antenati.AntenatiDownloader:
+    """Build an AntenatiDownloader against the mocked gallery+manifest."""
+    return antenati.AntenatiDownloader(GALLERY_URL, first=0, last=None)

--- a/tests/fixtures/gallery.html
+++ b/tests/fixtures/gallery.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<title>Gallery</title>
+</head>
+<body>
+<div id="viewer"></div>
+<script>
+  var manifestId = 'https://iiif.example.org/ark/12657/iiif-19944535/manifest';
+  var viewerOptions = {showNavigator: true};
+  initViewer(manifestId, viewerOptions);
+</script>
+</body>
+</html>

--- a/tests/fixtures/manifest_minimal.json
+++ b/tests/fixtures/manifest_minimal.json
@@ -1,0 +1,65 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://iiif.example.org/ark/12657/iiif-19944535/manifest",
+  "@type": "sc:Manifest",
+  "label": "Test gallery",
+  "metadata": [
+    {"label": "Contesto archivistico", "value": "Stato civile italiano/Provincia di Test/Comune di Esempio"},
+    {"label": "Titolo", "value": "1900"},
+    {"label": "Tipologia", "value": "Nati"},
+    {"label": "Note", "value": "Test fixture, not real data"}
+  ],
+  "sequences": [
+    {
+      "@id": "https://iiif.example.org/ark/12657/iiif-19944535/sequence/normal",
+      "@type": "sc:Sequence",
+      "canvases": [
+        {
+          "@id": "https://iiif.example.org/ark/12657/iiif-19944535/canvas/p1",
+          "@type": "sc:Canvas",
+          "label": "0001",
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "resource": {
+                "@id": "https://iiif.example.org/iiif/img1/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://iiif.example.org/ark/12657/iiif-19944535/canvas/p2",
+          "@type": "sc:Canvas",
+          "label": "0002",
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "resource": {
+                "@id": "https://iiif.example.org/iiif/img2/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg"
+              }
+            }
+          ]
+        },
+        {
+          "@id": "https://iiif.example.org/ark/12657/iiif-19944535/canvas/p3",
+          "@type": "sc:Canvas",
+          "label": "0003",
+          "images": [
+            {
+              "@type": "oa:Annotation",
+              "resource": {
+                "@id": "https://iiif.example.org/iiif/img3/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_check_dir.py
+++ b/tests/test_check_dir.py
@@ -1,0 +1,28 @@
+"""Tests for ``AntenatiDownloader.check_dir`` filesystem behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from antenati import AntenatiDownloader
+
+
+def test_check_dir_creates_target_under_parent(downloader: AntenatiDownloader, tmp_path: Path) -> None:
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    assert downloader.dirname.is_dir()
+    assert downloader.dirname.parent == tmp_path
+
+
+def test_check_dir_raises_when_target_exists_and_non_interactive(downloader: AntenatiDownloader, tmp_path: Path) -> None:
+    target = tmp_path / str(downloader.dirname)
+    target.mkdir()
+    with pytest.raises(RuntimeError, match='already exists'):
+        downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+
+
+def test_check_dir_without_parent_uses_cwd(downloader: AntenatiDownloader, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    downloader.check_dir(interactive=False)
+    assert (tmp_path / downloader.dirname).is_dir()

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -1,0 +1,176 @@
+"""End-to-end tests for ``AntenatiDownloader.run`` with mocked HTTP.
+
+These tests are the main safety net: they exercise the full happy path
+(gallery -> manifest -> per-image download -> filesystem writes) and a few
+key failure modes so the upcoming refactor cannot regress them silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import responses
+
+import antenati
+from antenati import AntenatiDownloader, ProgressBar
+from tests.conftest import GALLERY_URL, TINY_JPEG
+
+
+def _null_progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _t: None, update=lambda: None)
+
+
+def _image_url(canvas_label: str, size: int) -> str:
+    """Mirror ``__manipulate_url`` for the IIIF URL each canvas will fetch."""
+    base = f'https://iiif.example.org/iiif/img{canvas_label[-1]}'
+    size_part = f'!{size},{size}' if size > 0 else 'pct:100'
+    return f'{base}/full/{size_part}/0/default.jpg'
+
+
+@pytest.fixture
+def downloader_in_tmp(downloader: AntenatiDownloader, tmp_path: Path) -> AntenatiDownloader:
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    return downloader
+
+
+def test_run_downloads_all_images_full_size(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    total = downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+    assert total == 3 * len(TINY_JPEG)
+    files = sorted(p.name for p in downloader_in_tmp.dirname.iterdir())
+    assert files == ['0001.jpg', '0002.jpg', '0003.jpg']
+
+
+def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    size = 1234
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, size),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    total = downloader_in_tmp.run(n_workers=2, size=size, progress=_null_progress())
+    assert total == 3 * len(TINY_JPEG)
+
+
+def test_run_partial_failure_raises_with_summary(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    # First image succeeds, second 500s, third succeeds.
+    mocked_http.add(
+        responses.GET,
+        _image_url('0001', 0),
+        body=TINY_JPEG,
+        status=200,
+        content_type='image/jpeg',
+    )
+    mocked_http.add(
+        responses.GET,
+        _image_url('0002', 0),
+        body='boom',
+        status=500,
+        content_type='text/plain',
+    )
+    mocked_http.add(
+        responses.GET,
+        _image_url('0003', 0),
+        body=TINY_JPEG,
+        status=200,
+        content_type='image/jpeg',
+    )
+    with pytest.raises(RuntimeError, match=r'Failed to download 1 image'):
+        downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+
+
+def test_run_progress_callbacks_are_invoked(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    set_total_calls: list[int] = []
+    update_count = [0]
+
+    def _update() -> None:
+        update_count[0] += 1
+
+    progress = ProgressBar(set_total=set_total_calls.append, update=_update)
+    downloader_in_tmp.run(n_workers=2, size=0, progress=progress)
+    assert set_total_calls == [3]
+    assert update_count[0] == 3
+
+
+def test_run_filename_uses_image_extension(mocked_http, tmp_path: Path) -> None:
+    # Construct a downloader with a single canvas served as PNG so we can
+    # observe ``guess_extension`` picking up a different extension.
+    dl = AntenatiDownloader(GALLERY_URL, first=0, last=1)
+    dl.check_dir(parentdir=str(tmp_path), interactive=False)
+    mocked_http.add(
+        responses.GET,
+        _image_url('0001', 0),
+        body=TINY_JPEG,  # bytes are irrelevant, content-type drives extension
+        status=200,
+        content_type='image/png',
+    )
+    dl.run(n_workers=1, size=0, progress=_null_progress())
+    assert (dl.dirname / '0001.png').is_file()
+
+
+def test_run_with_first_last_range_downloads_subset(mocked_http, tmp_path: Path) -> None:
+    dl = AntenatiDownloader(GALLERY_URL, first=1, last=3)
+    dl.check_dir(parentdir=str(tmp_path), interactive=False)
+    for label in ('0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    dl.run(n_workers=2, size=0, progress=_null_progress())
+    files = sorted(p.name for p in dl.dirname.iterdir())
+    assert files == ['0002.jpg', '0003.jpg']
+
+
+def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    # All three respond with a content-type ``guess_extension`` cannot map.
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='application/x-no-such-format',
+        )
+    with pytest.raises(RuntimeError, match=r'Failed to download 3 image'):
+        downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+
+
+def test_run_cli_uses_tqdm_progress_bar(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    total = downloader_in_tmp.run_cli(n_workers=2, size=0)
+    assert total == 3 * len(TINY_JPEG)
+
+
+def test_progress_bar_dataclass_shape() -> None:
+    bar = antenati.ProgressBar(set_total=lambda _t: None, update=lambda: None)
+    assert callable(bar.set_total)
+    assert callable(bar.update)

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -1,0 +1,133 @@
+"""Tests for the IIIF gallery parsing path.
+
+Covers ``__get_archive_id``, ``__get_iiif_manifest`` (including the manifest
+URL regex on the gallery HTML), ``__get_content_type`` /
+``__get_content_charset``, and the AWS WAF challenge detection in ``__get``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import responses
+from requests import Session
+
+import antenati
+from antenati import AntenatiDownloader
+from tests.conftest import ARCHIVE_ID, GALLERY_URL, MANIFEST_URL
+
+# Reach into the name-mangled private methods. These will become public
+# pure functions in the upcoming refactor (PR-3); the indirection is
+# intentionally ugly so the rename is impossible to miss.
+_get_content_type = AntenatiDownloader._AntenatiDownloader__get_content_type  # type: ignore[attr-defined]
+_get_content_charset = AntenatiDownloader._AntenatiDownloader__get_content_charset  # type: ignore[attr-defined]
+
+
+def test_archive_id_is_extracted_from_url(downloader: AntenatiDownloader) -> None:
+    assert downloader.archive_id == ARCHIVE_ID
+
+
+def test_archive_id_raises_when_url_lacks_two_numbers(mocked_http) -> None:
+    with pytest.raises(RuntimeError, match='Cannot get archive ID'):
+        AntenatiDownloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
+
+
+def test_manifest_is_loaded_from_gallery_html(downloader: AntenatiDownloader) -> None:
+    assert downloader.manifest['@id'] == MANIFEST_URL
+    assert len(downloader.manifest['sequences'][0]['canvases']) == 3
+
+
+def test_gallery_url_is_recorded(downloader: AntenatiDownloader) -> None:
+    assert downloader.url == GALLERY_URL
+
+
+def test_canvases_are_sliced_by_first_last(mocked_http) -> None:
+    dl = AntenatiDownloader(GALLERY_URL, first=1, last=2)
+    assert dl.gallery_length == 1
+    assert dl.canvases[0]['label'] == '0002'
+
+
+def test_first_last_full_range(mocked_http) -> None:
+    dl = AntenatiDownloader(GALLERY_URL, first=0, last=None)
+    assert dl.gallery_length == 3
+
+
+def test_no_manifest_line_raises(gallery_html: str) -> None:
+    bad_html = '<html><body>no manifest here</body></html>'
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            GALLERY_URL,
+            body=bad_html,
+            status=200,
+            content_type='text/html; charset=utf-8',
+        )
+        with pytest.raises(RuntimeError, match='No IIIF manifest found'):
+            AntenatiDownloader(GALLERY_URL, 0, None)
+
+
+def test_invalid_manifest_line_raises() -> None:
+    # Has the keyword but no quoted URL: the regex still matches an empty
+    # group, exposing the fragility the refactor will address. For now we
+    # lock in the *current* behaviour so refactoring can't silently change
+    # it.
+    bad_html = '<script>var manifestId = noQuotesHere;</script>'
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            GALLERY_URL,
+            body=bad_html,
+            status=200,
+            content_type='text/html; charset=utf-8',
+        )
+        with pytest.raises(Exception):  # noqa: B017 - locks current behaviour
+            AntenatiDownloader(GALLERY_URL, 0, None)
+
+
+def test_waf_challenge_is_detected() -> None:
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            GALLERY_URL,
+            body='challenge',
+            status=202,
+            headers={'x-amzn-waf-action': 'challenge'},
+            content_type='text/html; charset=utf-8',
+        )
+        with pytest.raises(RuntimeError, match='AWS WAF challenge'):
+            AntenatiDownloader(GALLERY_URL, 0, None)
+
+
+def test_get_content_type_strips_parameters() -> None:
+    session = Session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/x',
+            body='ok',
+            status=200,
+            content_type='text/html; charset=utf-8',
+        )
+        reply = session.get('https://example.org/x')
+    assert _get_content_type(reply) == 'text/html'
+
+
+def test_get_content_charset() -> None:
+    session = Session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/x',
+            body='ok',
+            status=200,
+            content_type='application/json; charset=utf-8',
+        )
+        reply = session.get('https://example.org/x')
+    assert _get_content_charset(reply) == 'utf-8'
+
+
+def test_default_thread_count_constant() -> None:
+    assert antenati.DEFAULT_N_THREADS == 2
+
+
+def test_default_size_constant() -> None:
+    assert antenati.DEFAULT_SIZE == 0

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,41 @@
+"""Tests for metadata extraction and directory name generation."""
+
+from __future__ import annotations
+
+import pytest
+
+from antenati import AntenatiDownloader
+
+# Name-mangled private accessor — see test_iiif_parsing.py for context.
+_get_metadata_content = (
+    AntenatiDownloader._AntenatiDownloader__get_metadata_content  # type: ignore[attr-defined]
+)
+
+
+def test_metadata_lookup_by_label(downloader: AntenatiDownloader) -> None:
+    assert _get_metadata_content(downloader, 'Titolo') == '1900'
+    assert _get_metadata_content(downloader, 'Tipologia') == 'Nati'
+
+
+def test_metadata_lookup_unknown_label_raises(downloader: AntenatiDownloader) -> None:
+    with pytest.raises(RuntimeError, match='Cannot get'):
+        _get_metadata_content(downloader, 'does-not-exist')
+
+
+def test_generate_dirname_combines_metadata_and_archive_id(
+    downloader: AntenatiDownloader,
+) -> None:
+    # slugify lowercases and replaces slashes/spaces with single dashes
+    name = str(downloader.dirname)
+    assert '1900' in name
+    assert 'nati' in name
+    assert downloader.archive_id in name
+    assert 'stato-civile-italiano' in name
+
+
+def test_print_gallery_info_outputs_metadata(downloader: AntenatiDownloader, capsys: pytest.CaptureFixture[str]) -> None:
+    downloader.print_gallery_info()
+    out = capsys.readouterr().out
+    assert 'Contesto archivistico' in out
+    assert 'Tipologia' in out
+    assert '3 images found.' in out

--- a/tests/test_url_manipulation.py
+++ b/tests/test_url_manipulation.py
@@ -1,0 +1,30 @@
+"""Tests for ``__manipulate_url``: the IIIF size rewriter."""
+
+from __future__ import annotations
+
+import pytest
+
+from antenati import AntenatiDownloader
+
+_manipulate_url = (
+    AntenatiDownloader._AntenatiDownloader__manipulate_url  # type: ignore[attr-defined]
+)
+
+ORIGINAL = 'https://iiif.example.org/iiif/img1/full/full/0/default.jpg'
+
+
+def test_size_zero_uses_pct_100() -> None:
+    rewritten = _manipulate_url(ORIGINAL, 0)
+    assert rewritten == 'https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg'
+
+
+@pytest.mark.parametrize('size', [200, 1000, 5000])
+def test_positive_size_uses_constrained_box(size: int) -> None:
+    rewritten = _manipulate_url(ORIGINAL, size)
+    assert f'/full/!{size},{size}/0/' in rewritten
+    assert '/full/full/0/' not in rewritten
+
+
+def test_url_without_full_full_is_returned_unchanged() -> None:
+    weird = 'https://iiif.example.org/iiif/img1/info.json'
+    assert _manipulate_url(weird, 0) == weird


### PR DESCRIPTION
Before extracting modules out of antenati.py, lock in the current observable behaviour with a fully offline test suite. This is the safety net the planned refactor PRs need to land without silent regressions.

- tests/fixtures/: shaped-like-the-real-Portale gallery.html and IIIF manifest JSON, plus a tiny JPEG payload. URLs are sanitised to match the (intentionally fragile) regex in antenati.py:121, so the existing parser keeps passing while the upcoming refactor will broaden it.
- tests/conftest.py: shared fixtures (gallery_html, manifest_*, mocked_http via `responses`, downloader factory).
- 35 tests covering: archive ID extraction, manifest URL parsing, Content-Type/charset decoding, AWS WAF challenge detection, metadata lookup, generate_dirname slugification, the IIIF size-rewrite variants, the full run() flow at full-size and constrained sizes, partial-failure reporting, ProgressBar callbacks, file extension detection from Content-Type, and check_dir directory creation/clash.
- requirements-dev.txt: pins responses + the existing tool versions.
- CI: lint job now installs from requirements-dev.txt; offline tests run via `pytest -m "not integration"` and gate the live-download job.

The private name-mangled accessors (`_AntenatiDownloader__*`) used by a few tests are deliberately ugly so they cannot be ignored once the upcoming refactor moves those methods into pure modules.