### PR TITLE
Extract antenati_http and antenati_iiif as pure modules

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,7 +27,7 @@ jobs:
       run: ruff format --check .
 
     - name: Mypy
-      run: mypy antenati.py antenati_gui.py
+      run: mypy antenati.py antenati_gui.py antenati_http.py antenati_iiif.py
 
     - name: Pytest (offline only)
       run: pytest -m "not integration"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     rev: v1.19.1
     hooks:
       - id: mypy
-        files: ^(antenati|antenati_gui)\.py$
+        files: ^(antenati|antenati_gui|antenati_http|antenati_iiif)\.py$
         additional_dependencies:
           - types-requests

--- a/antenati.py
+++ b/antenati.py
@@ -13,21 +13,21 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from email.message import Message
 from json import loads
 from mimetypes import guess_extension
 from os import mkdir, path
 from pathlib import Path
-from re import findall, search
 from sys import exit
 from typing import Any, Optional
 
 from click import confirm, echo
 from humanize import naturalsize
-from requests import Response, Session
-from requests.utils import default_headers
+from requests import Session
 from slugify import slugify
 from tqdm import tqdm
+
+import antenati_http
+import antenati_iiif
 
 
 @dataclass
@@ -60,84 +60,28 @@ class AntenatiDownloader:
 
     def __init__(self, url: str, first: int, last: int):
         self.url = url
-        self.session = Session()
-        self.session.headers = self.__http_headers()
-        self.archive_id = self.__get_archive_id()
-        self.manifest = self.__get_iiif_manifest()
-        self.canvases = self.manifest['sequences'][0]['canvases'][first:last]
+        self.session = antenati_http.build_session()
+        self.archive_id = antenati_iiif.get_archive_id_from_url(url)
+        self.manifest = self.__load_manifest()
+        self.canvases = antenati_iiif.slice_canvases(self.manifest, first, last)
         self.dirname = self.__generate_dirname()
         self.gallery_length = len(self.canvases)
 
-    @staticmethod
-    def __http_headers():
-        """Generate HTTP headers to improve speed and to behave as a browser"""
-        # SAN server return 403 if HTTP headers are not properly set.
-        # - User-Agent: required
-        # - Referer: required
-        # - Origin: not required
-        # Other headers are set to improve performance.
-        headers = default_headers()
-        headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
-        headers['Referer'] = 'https://antenati.cultura.gov.it/'
-        return headers
-
-    def __get_archive_id(self) -> str:
-        """Get numeric archive ID from the URL"""
-        archive_id_pattern = findall(r'(\d+)', self.url)
-        if len(archive_id_pattern) < 2:
-            raise RuntimeError(f'Cannot get archive ID from {self.url}')
-        return archive_id_pattern[1]
-
-    @staticmethod
-    def __get_content_type(http_reply: Response) -> str:
-        """Decode Content-Type header using email module."""
-        msg = Message()
-        msg['Content-Type'] = http_reply.headers['Content-Type']
-        return msg.get_content_type()
-
-    @staticmethod
-    def __get_content_charset(http_reply: Response):
-        """Decode Content-Type header using email module."""
-        msg = Message()
-        msg['Content-Type'] = http_reply.headers['Content-Type']
-        return msg.get_content_charset()
-
-    def __get(self, url: str) -> Response:
-        """Get HTTP reply from URL"""
-        http_reply = self.session.get(url)
-        http_reply.raise_for_status()
-        if http_reply.status_code == 202 and http_reply.headers.get('x-amzn-waf-action') == 'challenge':
-            raise RuntimeError(f'{http_reply.url}: AWS WAF challenge cannot be bypassed. See https://github.com/gcerretani/antenati/issues/25 for details.')
-        return http_reply
-
-    def __get_iiif_manifest(self) -> dict[str, Any]:
-        """Get IIIF manifest as JSON from Portale Antenati gallery page"""
-        http_reply = self.__get(self.url)
-        charset = self.__get_content_charset(http_reply)
-        html_content = http_reply.content.decode(charset).splitlines()
-        manifest_line = next((line for line in html_content if 'manifestId' in line), None)
-        if not manifest_line:
-            raise RuntimeError(f'No IIIF manifest found at {self.url}')
-        manifest_url_pattern = search(r'\'([A-Za-z0-9.:/-]*)\'', manifest_line)
-        if not manifest_url_pattern:
-            raise RuntimeError(f'Invalid IIIF manifest line found at {self.url}')
-        manifest_url = manifest_url_pattern.group(1)
-        http_reply = self.__get(manifest_url)
-        charset = self.__get_content_charset(http_reply)
-        return loads(http_reply.content.decode(charset))
-
-    def __get_metadata_content(self, label: str) -> str:
-        """Get metadata content of IIIF manifest given its label"""
-        try:
-            return next((i['value'] for i in self.manifest['metadata'] if i['label'] == label))
-        except StopIteration as exc:
-            raise RuntimeError(f'Cannot get {label} from manifest') from exc
+    def __load_manifest(self) -> dict[str, Any]:
+        """Fetch the gallery page, extract the manifest URL, and load it as JSON."""
+        gallery_reply = antenati_http.fetch(self.session, self.url)
+        gallery_charset = antenati_http.get_content_charset(gallery_reply)
+        gallery_html = gallery_reply.content.decode(gallery_charset)
+        manifest_url = antenati_iiif.parse_manifest_url_from_html(gallery_html, self.url)
+        manifest_reply = antenati_http.fetch(self.session, manifest_url)
+        manifest_charset = antenati_http.get_content_charset(manifest_reply)
+        return loads(manifest_reply.content.decode(manifest_charset))
 
     def __generate_dirname(self) -> Path:
         """Generate directory name from info in IIIF manifest"""
-        context = self.__get_metadata_content('Contesto archivistico')
-        year = self.__get_metadata_content('Titolo')
-        typology = self.__get_metadata_content('Tipologia')
+        context = antenati_iiif.get_metadata_value(self.manifest, 'Contesto archivistico')
+        year = antenati_iiif.get_metadata_value(self.manifest, 'Titolo')
+        typology = antenati_iiif.get_metadata_value(self.manifest, 'Tipologia')
         return Path(slugify(f'{context}-{year}-{typology}-{self.archive_id}'))
 
     def print_gallery_info(self) -> None:
@@ -163,27 +107,14 @@ class AntenatiDownloader:
         else:
             mkdir(self.dirname)
 
-    @staticmethod
-    def __manipulate_url(url: str, size: int) -> str:
-        """Get full size string for IIIF request"""
-        # SAN server return 403 on certain IIIF requests:
-        # - /full/full/0/ (full image, deprecated)
-        # - /full/max/0/ (max size based on height and width declared in IIIF manifest)
-        # We use an alternative that seems to work, as of today.
-        if size > 0:
-            size_str = f'/full/!{size},{size}/0/'
-        else:
-            size_str = '/full/pct:100/0/'
-        return url.replace('/full/full/0/', size_str)
-
     def __thread_main(self, canvas: dict[str, Any], size: int) -> int:
         """Main function for each thread"""
         label = slugify(canvas['label'])
         try:
-            manifest_url: str = canvas['images'][0]['resource']['@id']
-            url = self.__manipulate_url(manifest_url, size)
-            http_reply = self.__get(url)
-            content_type = self.__get_content_type(http_reply)
+            image_url = antenati_iiif.image_url_for_canvas(canvas)
+            url = antenati_iiif.manipulate_image_url(image_url, size)
+            http_reply = antenati_http.fetch(self.session, url)
+            content_type = antenati_http.get_content_type(http_reply)
             extension = guess_extension(content_type)
             if not extension:
                 raise RuntimeError(f'{url}: Unable to guess extension "{content_type}"')

--- a/antenati_http.py
+++ b/antenati_http.py
@@ -1,0 +1,86 @@
+"""HTTP plumbing for the Portale Antenati downloader.
+
+Exposes a single small surface that ``antenati.AntenatiDownloader`` (and any
+future module) can lean on without re-implementing the SAN-server quirks:
+
+- :func:`build_session` returns a :class:`requests.Session` preconfigured
+  with the headers required by the SAN reverse proxy.
+- :func:`fetch` performs a ``GET`` and turns the AWS WAF challenge response
+  (HTTP 202 with ``x-amzn-waf-action: challenge``) into a clean
+  :class:`RuntimeError`.
+- :func:`get_content_type` / :func:`get_content_charset` parse a response's
+  ``Content-Type`` header.
+
+This module is intentionally side-effect free at import time: it only
+declares helpers. Retry policies and structured logging will be added in a
+later refactor step.
+"""
+
+from __future__ import annotations
+
+from email.message import Message
+from typing import Optional
+
+from requests import Response, Session
+from requests.utils import default_headers
+
+# These are observable behaviours of the SAN server; pulling them into
+# named constants makes the WAF detection explicit and lets tests assert
+# against the contract instead of magic strings.
+WAF_CHALLENGE_STATUS: int = 202
+WAF_CHALLENGE_HEADER: str = 'x-amzn-waf-action'
+WAF_CHALLENGE_VALUE: str = 'challenge'
+
+# Mimic a current Edge-on-Windows fingerprint. The SAN reverse proxy 403s
+# requests that look automated, so this header is part of the contract.
+_USER_AGENT: str = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
+_REFERER: str = 'https://antenati.cultura.gov.it/'
+
+
+def _http_headers():
+    """Build the header set required to reach the Portale Antenati."""
+    headers = default_headers()
+    headers['User-Agent'] = _USER_AGENT
+    headers['Referer'] = _REFERER
+    return headers
+
+
+def build_session() -> Session:
+    """Return a Session preconfigured for Portale Antenati requests."""
+    session = Session()
+    session.headers = _http_headers()
+    return session
+
+
+def fetch(session: Session, url: str) -> Response:
+    """GET ``url`` through ``session`` and turn known soft-failures into errors.
+
+    Raises
+    ------
+    requests.HTTPError
+        If the server returned a 4xx/5xx status.
+    RuntimeError
+        If the server returned an AWS WAF challenge (HTTP 202 with the
+        ``x-amzn-waf-action: challenge`` header). There is currently no
+        bypass; surfacing this as a distinct error helps callers diagnose
+        the problem without parsing HTML.
+    """
+    reply = session.get(url)
+    reply.raise_for_status()
+    if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
+        raise RuntimeError(f'{reply.url}: AWS WAF challenge cannot be bypassed. See https://github.com/gcerretani/antenati/issues/25 for details.')
+    return reply
+
+
+def get_content_type(reply: Response) -> str:
+    """Return the bare content-type (no parameters) from a response."""
+    msg = Message()
+    msg['Content-Type'] = reply.headers['Content-Type']
+    return msg.get_content_type()
+
+
+def get_content_charset(reply: Response) -> Optional[str]:
+    """Return the charset declared in a response's Content-Type, if any."""
+    msg = Message()
+    msg['Content-Type'] = reply.headers['Content-Type']
+    return msg.get_content_charset()

--- a/antenati_iiif.py
+++ b/antenati_iiif.py
@@ -1,0 +1,109 @@
+"""Pure IIIF helpers for the Portale Antenati gallery format.
+
+All functions in this module work on plain Python data (strings, dicts).
+None of them perform I/O, which makes them straightforward to unit test
+offline. ``antenati.AntenatiDownloader`` orchestrates HTTP fetching and
+delegates the parsing to these helpers.
+
+The current implementations preserve the exact behaviour of the legacy
+single-file ``antenati.py`` -- including a couple of known fragilities in
+the manifest URL regex and the unguarded JSON accesses. Hardening those
+will land in a dedicated PR with its own tests.
+"""
+
+from __future__ import annotations
+
+from re import findall, search
+from typing import Any, Optional
+
+# The gallery HTML embeds the IIIF manifest URL inside a JavaScript
+# ``manifestId = '<URL>'`` assignment. The character class below is what
+# the legacy parser accepted; broadening it (e.g. to allow underscores or
+# query strings) is a behaviour change and is deliberately deferred.
+_MANIFEST_URL_PATTERN: str = r'\'([A-Za-z0-9.:/-]*)\''
+_MANIFEST_KEYWORD: str = 'manifestId'
+
+# IIIF size syntax: ``/full/full/0/`` is the legacy "give me everything"
+# template baked into the manifest. We rewrite it to one of the size
+# variants the SAN server still serves.
+_FULL_SIZE_TEMPLATE: str = '/full/full/0/'
+
+
+def get_archive_id_from_url(url: str) -> str:
+    """Return the archive ID embedded in a Portale Antenati gallery URL.
+
+    Antenati gallery URLs contain at least two integers; the second one is
+    the archive ID. Example::
+
+        https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/...
+                                            ^^^^^ ^^^^^^^^
+                                            ark   archive id
+    """
+    numbers = findall(r'(\d+)', url)
+    if len(numbers) < 2:
+        raise RuntimeError(f'Cannot get archive ID from {url}')
+    return numbers[1]
+
+
+def parse_manifest_url_from_html(html: str, source_url: str) -> str:
+    """Extract the IIIF manifest URL from a Portale Antenati gallery page.
+
+    Parameters
+    ----------
+    html:
+        The decoded HTML body of the gallery page.
+    source_url:
+        The URL the HTML came from. Only used to produce informative error
+        messages -- this function performs no I/O.
+    """
+    manifest_line = next(
+        (line for line in html.splitlines() if _MANIFEST_KEYWORD in line),
+        None,
+    )
+    if not manifest_line:
+        raise RuntimeError(f'No IIIF manifest found at {source_url}')
+    match = search(_MANIFEST_URL_PATTERN, manifest_line)
+    if not match:
+        raise RuntimeError(f'Invalid IIIF manifest line found at {source_url}')
+    return match.group(1)
+
+
+def get_metadata_value(manifest: dict[str, Any], label: str) -> str:
+    """Return the value of the ``label`` entry in a manifest's metadata.
+
+    The IIIF manifest metadata is a list of ``{label, value}`` dicts.
+    """
+    try:
+        return next(i['value'] for i in manifest['metadata'] if i['label'] == label)
+    except StopIteration as exc:
+        raise RuntimeError(f'Cannot get {label} from manifest') from exc
+
+
+def slice_canvases(manifest: dict[str, Any], first: int, last: Optional[int]) -> list[dict[str, Any]]:
+    """Return ``manifest['sequences'][0]['canvases'][first:last]``.
+
+    Encapsulating this single index access keeps the assumption (single
+    sequence at index 0) in one place; a future PR will replace it with a
+    defensive lookup that raises a typed ``ManifestError`` instead.
+    """
+    return manifest['sequences'][0]['canvases'][first:last]
+
+
+def image_url_for_canvas(canvas: dict[str, Any]) -> str:
+    """Return the image URL declared by an IIIF canvas."""
+    return canvas['images'][0]['resource']['@id']
+
+
+def manipulate_image_url(url: str, size: int) -> str:
+    """Rewrite an IIIF image URL to request a specific output size.
+
+    The Portale Antenati SAN server currently 403s on ``/full/full/0/``
+    (deprecated) and ``/full/max/0/``. Replace those with one of the
+    variants that still works:
+
+    - ``size > 0`` -> ``/full/!{size},{size}/0/`` (constrain by box)
+    - ``size == 0`` -> ``/full/pct:100/0/`` (full resolution, current
+      working alternative)
+    """
+    size_str = f'/full/!{size},{size}/0/' if size > 0 else '/full/pct:100/0/'
+    return url.replace(_FULL_SIZE_TEMPLATE, size_str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ quote-style = "single"
 exclude = ["antenati.py", "antenati_gui.py"]
 
 [tool.mypy]
-python_version = "3.9"
+# mypy 1.19+ no longer supports type-checking against Python 3.9. The code
+# itself still targets py39 (see ruff's target-version) and is verified to
+# import on 3.9 in CI; type narrowing just gets analysed as if running on
+# 3.10. Bump this in sync with the runtime minimum if/when 3.9 is dropped.
+python_version = "3.10"
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unreachable = true

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,71 @@
+"""Focused unit tests for :mod:`antenati_http`."""
+
+from __future__ import annotations
+
+import pytest
+import responses
+
+import antenati_http
+
+
+def test_build_session_sets_required_headers() -> None:
+    session = antenati_http.build_session()
+    assert 'antenati.cultura.gov.it' in session.headers['Referer']
+    assert 'Mozilla/5.0' in session.headers['User-Agent']
+
+
+def test_fetch_returns_response_on_2xx() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/ok',
+            body='hi',
+            status=200,
+            content_type='text/plain',
+        )
+        reply = antenati_http.fetch(session, 'https://example.org/ok')
+    assert reply.text == 'hi'
+
+
+def test_fetch_raises_on_http_error() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/boom',
+            body='nope',
+            status=500,
+            content_type='text/plain',
+        )
+        with pytest.raises(Exception):  # noqa: B017 - requests.HTTPError subclass
+            antenati_http.fetch(session, 'https://example.org/boom')
+
+
+def test_fetch_raises_on_waf_challenge() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/challenge',
+            body='challenge',
+            status=antenati_http.WAF_CHALLENGE_STATUS,
+            headers={antenati_http.WAF_CHALLENGE_HEADER: antenati_http.WAF_CHALLENGE_VALUE},
+            content_type='text/html; charset=utf-8',
+        )
+        with pytest.raises(RuntimeError, match='AWS WAF challenge'):
+            antenati_http.fetch(session, 'https://example.org/challenge')
+
+
+def test_fetch_does_not_treat_plain_202_as_waf() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/accepted',
+            body='queued',
+            status=202,
+            content_type='text/plain',
+        )
+        reply = antenati_http.fetch(session, 'https://example.org/accepted')
+    assert reply.status_code == 202

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -1,8 +1,8 @@
 """Tests for the IIIF gallery parsing path.
 
-Covers ``__get_archive_id``, ``__get_iiif_manifest`` (including the manifest
-URL regex on the gallery HTML), ``__get_content_type`` /
-``__get_content_charset``, and the AWS WAF challenge detection in ``__get``.
+Exercises both the pure helpers in :mod:`antenati_iiif` /
+:mod:`antenati_http` and the orchestration in
+:class:`antenati.AntenatiDownloader`.
 """
 
 from __future__ import annotations
@@ -12,21 +12,26 @@ import responses
 from requests import Session
 
 import antenati
+import antenati_http
+import antenati_iiif
 from antenati import AntenatiDownloader
 from tests.conftest import ARCHIVE_ID, GALLERY_URL, MANIFEST_URL
-
-# Reach into the name-mangled private methods. These will become public
-# pure functions in the upcoming refactor (PR-3); the indirection is
-# intentionally ugly so the rename is impossible to miss.
-_get_content_type = AntenatiDownloader._AntenatiDownloader__get_content_type  # type: ignore[attr-defined]
-_get_content_charset = AntenatiDownloader._AntenatiDownloader__get_content_charset  # type: ignore[attr-defined]
 
 
 def test_archive_id_is_extracted_from_url(downloader: AntenatiDownloader) -> None:
     assert downloader.archive_id == ARCHIVE_ID
 
 
-def test_archive_id_raises_when_url_lacks_two_numbers(mocked_http) -> None:
+def test_archive_id_helper_returns_second_integer() -> None:
+    assert antenati_iiif.get_archive_id_from_url(GALLERY_URL) == ARCHIVE_ID
+
+
+def test_archive_id_helper_raises_when_url_lacks_two_numbers() -> None:
+    with pytest.raises(RuntimeError, match='Cannot get archive ID'):
+        antenati_iiif.get_archive_id_from_url('https://antenati.cultura.gov.it/no-numbers/')
+
+
+def test_constructor_raises_when_url_lacks_two_numbers(mocked_http) -> None:
     with pytest.raises(RuntimeError, match='Cannot get archive ID'):
         AntenatiDownloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
 
@@ -51,7 +56,17 @@ def test_first_last_full_range(mocked_http) -> None:
     assert dl.gallery_length == 3
 
 
-def test_no_manifest_line_raises(gallery_html: str) -> None:
+def test_parse_manifest_url_from_html_extracts_quoted_url() -> None:
+    html = "<script>var manifestId = 'https://example.org/m';</script>"
+    assert antenati_iiif.parse_manifest_url_from_html(html, 'src') == 'https://example.org/m'
+
+
+def test_parse_manifest_url_no_keyword_raises() -> None:
+    with pytest.raises(RuntimeError, match='No IIIF manifest found'):
+        antenati_iiif.parse_manifest_url_from_html('<html>nothing here</html>', 'src')
+
+
+def test_constructor_raises_when_html_lacks_manifest(gallery_html: str) -> None:
     bad_html = '<html><body>no manifest here</body></html>'
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -65,11 +80,10 @@ def test_no_manifest_line_raises(gallery_html: str) -> None:
             AntenatiDownloader(GALLERY_URL, 0, None)
 
 
-def test_invalid_manifest_line_raises() -> None:
-    # Has the keyword but no quoted URL: the regex still matches an empty
-    # group, exposing the fragility the refactor will address. For now we
-    # lock in the *current* behaviour so refactoring can't silently change
-    # it.
+def test_constructor_raises_on_invalid_manifest_line() -> None:
+    # Locks in the *current* (fragile) behaviour: ``manifestId`` keyword
+    # present but no quoted URL eventually raises. The exact exception type
+    # will become more specific in a later hardening PR.
     bad_html = '<script>var manifestId = noQuotesHere;</script>'
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -89,8 +103,8 @@ def test_waf_challenge_is_detected() -> None:
             responses.GET,
             GALLERY_URL,
             body='challenge',
-            status=202,
-            headers={'x-amzn-waf-action': 'challenge'},
+            status=antenati_http.WAF_CHALLENGE_STATUS,
+            headers={antenati_http.WAF_CHALLENGE_HEADER: antenati_http.WAF_CHALLENGE_VALUE},
             content_type='text/html; charset=utf-8',
         )
         with pytest.raises(RuntimeError, match='AWS WAF challenge'):
@@ -108,7 +122,7 @@ def test_get_content_type_strips_parameters() -> None:
             content_type='text/html; charset=utf-8',
         )
         reply = session.get('https://example.org/x')
-    assert _get_content_type(reply) == 'text/html'
+    assert antenati_http.get_content_type(reply) == 'text/html'
 
 
 def test_get_content_charset() -> None:
@@ -122,7 +136,7 @@ def test_get_content_charset() -> None:
             content_type='application/json; charset=utf-8',
         )
         reply = session.get('https://example.org/x')
-    assert _get_content_charset(reply) == 'utf-8'
+    assert antenati_http.get_content_charset(reply) == 'utf-8'
 
 
 def test_default_thread_count_constant() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,22 +4,18 @@ from __future__ import annotations
 
 import pytest
 
+import antenati_iiif
 from antenati import AntenatiDownloader
 
-# Name-mangled private accessor — see test_iiif_parsing.py for context.
-_get_metadata_content = (
-    AntenatiDownloader._AntenatiDownloader__get_metadata_content  # type: ignore[attr-defined]
-)
+
+def test_get_metadata_value_finds_label(manifest_dict: dict) -> None:
+    assert antenati_iiif.get_metadata_value(manifest_dict, 'Titolo') == '1900'
+    assert antenati_iiif.get_metadata_value(manifest_dict, 'Tipologia') == 'Nati'
 
 
-def test_metadata_lookup_by_label(downloader: AntenatiDownloader) -> None:
-    assert _get_metadata_content(downloader, 'Titolo') == '1900'
-    assert _get_metadata_content(downloader, 'Tipologia') == 'Nati'
-
-
-def test_metadata_lookup_unknown_label_raises(downloader: AntenatiDownloader) -> None:
+def test_get_metadata_value_unknown_label_raises(manifest_dict: dict) -> None:
     with pytest.raises(RuntimeError, match='Cannot get'):
-        _get_metadata_content(downloader, 'does-not-exist')
+        antenati_iiif.get_metadata_value(manifest_dict, 'does-not-exist')
 
 
 def test_generate_dirname_combines_metadata_and_archive_id(

--- a/tests/test_url_manipulation.py
+++ b/tests/test_url_manipulation.py
@@ -1,30 +1,31 @@
-"""Tests for ``__manipulate_url``: the IIIF size rewriter."""
+"""Tests for ``manipulate_image_url``: the IIIF size rewriter."""
 
 from __future__ import annotations
 
 import pytest
 
-from antenati import AntenatiDownloader
-
-_manipulate_url = (
-    AntenatiDownloader._AntenatiDownloader__manipulate_url  # type: ignore[attr-defined]
-)
+import antenati_iiif
 
 ORIGINAL = 'https://iiif.example.org/iiif/img1/full/full/0/default.jpg'
 
 
 def test_size_zero_uses_pct_100() -> None:
-    rewritten = _manipulate_url(ORIGINAL, 0)
+    rewritten = antenati_iiif.manipulate_image_url(ORIGINAL, 0)
     assert rewritten == 'https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg'
 
 
 @pytest.mark.parametrize('size', [200, 1000, 5000])
 def test_positive_size_uses_constrained_box(size: int) -> None:
-    rewritten = _manipulate_url(ORIGINAL, size)
+    rewritten = antenati_iiif.manipulate_image_url(ORIGINAL, size)
     assert f'/full/!{size},{size}/0/' in rewritten
     assert '/full/full/0/' not in rewritten
 
 
 def test_url_without_full_full_is_returned_unchanged() -> None:
     weird = 'https://iiif.example.org/iiif/img1/info.json'
-    assert _manipulate_url(weird, 0) == weird
+    assert antenati_iiif.manipulate_image_url(weird, 0) == weird
+
+
+def test_image_url_for_canvas_extracts_resource_id(manifest_dict: dict) -> None:
+    canvas = manifest_dict['sequences'][0]['canvases'][0]
+    assert antenati_iiif.image_url_for_canvas(canvas).endswith('/img1/full/full/0/default.jpg')


### PR DESCRIPTION
Pull the HTTP plumbing and the IIIF parsing out of AntenatiDownloader so they can be unit tested without an instance and reused by future entry points (e.g. an alternative CLI or batch tool).

- antenati_http.py: build_session(), fetch() with WAF-challenge detection, get_content_type/get_content_charset, plus named constants (WAF_CHALLENGE_STATUS/HEADER/VALUE) replacing the magic 202 + header literal at the old antenati.py:109.
- antenati_iiif.py: get_archive_id_from_url, parse_manifest_url_from_html, get_metadata_value, slice_canvases, image_url_for_canvas, manipulate_image_url. All side-effect free; behaviour is preserved byte-for-byte (including the known-fragile manifest URL regex; that hardening is a separate PR).
- antenati.py: AntenatiDownloader becomes a thin orchestrator that delegates to the two new modules. Public surface (class name, fields, methods, ProgressBar, ThreadError, DEFAULT_*) is unchanged so the GUI and any external scripts keep working.

Tests:
- Replace the ugly name-mangled accessors used in PR-2 with direct imports from antenati_iiif/antenati_http. Added a focused test_http.py for the new module (5 tests). The PR-2 safety-net tests still cover end-to-end behaviour through AntenatiDownloader, so a regression in the orchestration layer would still fail loudly.

Tooling:
- mypy now type-checks the four production modules (CI + pre-commit).
- mypy `python_version` bumped to 3.10 because mypy 1.19 dropped 3.9 support for the type-checker; the runtime minimum stays 3.9 (ruff target-version is unchanged).

45 tests pass offline in ~0.2s.