### PR TITLE
Extract Downloader + error hierarchy, drop Python 3.9 support

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,7 +27,7 @@ jobs:
       run: ruff format --check .
 
     - name: Mypy
-      run: mypy antenati.py antenati_gui.py antenati_http.py antenati_iiif.py
+      run: mypy antenati.py antenati_gui.py antenati_http.py antenati_iiif.py antenati_downloader.py antenati_errors.py
 
     - name: Pytest (offline only)
       run: pytest -m "not integration"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
     rev: v1.19.1
     hooks:
       - id: mypy
-        files: ^(antenati|antenati_gui|antenati_http|antenati_iiif)\.py$
+        files: ^(antenati|antenati_gui|antenati_http|antenati_iiif|antenati_downloader|antenati_errors)\.py$
         additional_dependencies:
           - types-requests

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Copy the link to the first page, and paste it in the Archive URL field of the wi
 ## CLI version
 
 ### Requirements
-The software is written in Python 3 and tested with Python 3.9. On Windows the version on the Microsoft Store is fine, on Linux use your distribution package manager.
+The software is written in Python 3 and requires Python 3.10 or newer. On Windows the version on the Microsoft Store is fine, on Linux use your distribution package manager.
 
 ### Usage
 Open your preferite terminal and change directory to where you've extracted the content of this repo. Then execute the following commands.

--- a/antenati.py
+++ b/antenati.py
@@ -10,184 +10,82 @@ __version__ = '5.0'
 __contact__ = 'https://gcerretani.github.io/antenati/'
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
-from json import loads
-from mimetypes import guess_extension
-from os import mkdir, path
-from pathlib import Path
-from sys import exit
-from typing import Any, Optional
 
-from click import confirm, echo
 from humanize import naturalsize
-from requests import Session
-from slugify import slugify
 from tqdm import tqdm
 
-import antenati_http
-import antenati_iiif
+from antenati_downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, Downloader, ProgressBar
+from antenati_errors import ThreadError
+
+# Backwards-compatible alias: external scripts and ``antenati_gui`` still
+# import ``antenati.AntenatiDownloader``. Removing the alias is a major
+# version bump scheduled for a later cleanup PR.
+AntenatiDownloader = Downloader
+
+# Keep ProgressBar / ThreadError / DEFAULT_* importable from ``antenati``
+# for the same reason. Re-exporting from the module makes the move
+# transparent to GUI code and any user scripts.
+__all__ = [
+    'DEFAULT_N_THREADS',
+    'DEFAULT_SIZE',
+    'AntenatiDownloader',
+    'Downloader',
+    'ProgressBar',
+    'ThreadError',
+    '__version__',
+    'run_cli',
+]
 
 
-@dataclass
-class ProgressBar:
-    """Progress Bar callbacks"""
-    set_total: Callable[[int], None]
-    update: Callable[[], None]
-
-
-class ThreadError(Exception):
-    """Container to be used with exception chaining."""
-    def __init__(self, label: str):
-        self.label = label
-
-
-DEFAULT_SIZE: int = 0
-DEFAULT_N_THREADS: int = 2
-
-
-class AntenatiDownloader:
-    """Downloader class"""
-
-    url: str
-    session: Session
-    archive_id: str
-    manifest: dict[str, Any]
-    canvases: list[dict[str, Any]]
-    dirname: Path
-    gallery_length: int
-
-    def __init__(self, url: str, first: int, last: int):
-        self.url = url
-        self.session = antenati_http.build_session()
-        self.archive_id = antenati_iiif.get_archive_id_from_url(url)
-        self.manifest = self.__load_manifest()
-        self.canvases = antenati_iiif.slice_canvases(self.manifest, first, last)
-        self.dirname = self.__generate_dirname()
-        self.gallery_length = len(self.canvases)
-
-    def __load_manifest(self) -> dict[str, Any]:
-        """Fetch the gallery page, extract the manifest URL, and load it as JSON."""
-        gallery_reply = antenati_http.fetch(self.session, self.url)
-        gallery_charset = antenati_http.get_content_charset(gallery_reply)
-        gallery_html = gallery_reply.content.decode(gallery_charset)
-        manifest_url = antenati_iiif.parse_manifest_url_from_html(gallery_html, self.url)
-        manifest_reply = antenati_http.fetch(self.session, manifest_url)
-        manifest_charset = antenati_http.get_content_charset(manifest_reply)
-        return loads(manifest_reply.content.decode(manifest_charset))
-
-    def __generate_dirname(self) -> Path:
-        """Generate directory name from info in IIIF manifest"""
-        context = antenati_iiif.get_metadata_value(self.manifest, 'Contesto archivistico')
-        year = antenati_iiif.get_metadata_value(self.manifest, 'Titolo')
-        typology = antenati_iiif.get_metadata_value(self.manifest, 'Tipologia')
-        return Path(slugify(f'{context}-{year}-{typology}-{self.archive_id}'))
-
-    def print_gallery_info(self) -> None:
-        """Print IIIF gallery info"""
-        for i in self.manifest['metadata']:
-            label = i['label']
-            value = i['value']
-            print(f'{label:<25}{value}')
-        print(f'{self.gallery_length} images found.')
-
-    def check_dir(self, parentdir: Optional[str] = None, interactive = True) -> None:
-        """Check if directory already exists and chdir to it"""
-        if parentdir is not None:
-            self.dirname = Path(parentdir) / self.dirname
-        print(f'Output directory: {self.dirname}')
-        if path.exists(self.dirname):
-            msg = f'Directory {self.dirname} already exists.'
-            if not interactive:
-                raise RuntimeError(msg)
-            echo(msg)
-            if not confirm('Do you want to proceed?'):
-                exit(1)
-        else:
-            mkdir(self.dirname)
-
-    def __thread_main(self, canvas: dict[str, Any], size: int) -> int:
-        """Main function for each thread"""
-        label = slugify(canvas['label'])
-        try:
-            image_url = antenati_iiif.image_url_for_canvas(canvas)
-            url = antenati_iiif.manipulate_image_url(image_url, size)
-            http_reply = antenati_http.fetch(self.session, url)
-            content_type = antenati_http.get_content_type(http_reply)
-            extension = guess_extension(content_type)
-            if not extension:
-                raise RuntimeError(f'{url}: Unable to guess extension "{content_type}"')
-            filename = self.dirname / f'{label}{extension}'
-            with open(filename, 'wb') as img_file:
-                img_file.write(http_reply.content)
-            http_reply_size = len(http_reply.content)
-            return http_reply_size
-        except Exception as ex:
-            raise ThreadError(label) from ex
-
-    @staticmethod
-    def __executor(max_workers: int) -> ThreadPoolExecutor:
-        """Create ThreadPoolExecutor with max_workers threads"""
-        return ThreadPoolExecutor(max_workers=max_workers)
-
-    def run_cli(self, n_workers: int, size: int) -> int:
-        """Main function spanning run function in a thread pool, with tqdm progress bar"""
-        with tqdm(unit='img') as progress:
-            progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore
-            return self.run(n_workers, size, progress_bar)
-
-    def run(self, n_workers: int, size: int, progress: ProgressBar) -> int:
-        """Main function spanning run function in a thread pool"""
-        with self.__executor(n_workers) as executor:
-            future_img = {executor.submit(self.__thread_main, i, size) for i in self.canvases}
-            progress.set_total(self.gallery_length)
-            gallery_size = 0
-            failed: dict[str, str] = {}
-            for future in as_completed(future_img):
-                progress.update()
-                try:
-                    gallery_size += future.result()
-                except ThreadError as ex:
-                    failed[ex.label] = str(ex.__cause__)
-                    continue
-            if failed:
-                msg = f'Failed to download {len(failed)} images:\n'
-                msg += '\n - '.join(f'{k}: {v}' for k, v in failed.items())
-                raise RuntimeError(msg)
-            return gallery_size
+def run_cli(downloader: Downloader, n_workers: int, size: int) -> int:
+    """Run the download with a tqdm progress bar attached."""
+    with tqdm(unit='img') as progress:
+        progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore[arg-type]
+        return downloader.run(n_workers, size, progress_bar)
 
 
 def main() -> None:
-    """Main"""
-
-    # Parse arguments
     parser = ArgumentParser(
         description=__doc__,
         epilog=__copyright__,
-        formatter_class=ArgumentDefaultsHelpFormatter
+        formatter_class=ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument('url', metavar='URL', type=str, help='url of the gallery page')
-    parser.add_argument('-s', '--size', type=int, help='image size in pixel (0 means full size)', default=DEFAULT_SIZE)
-    parser.add_argument('-n', '--nthreads', type=int, help='max n. of threads', default=DEFAULT_N_THREADS)
-    parser.add_argument('-f', '--first', type=int, help='first image to download', default=0)
-    parser.add_argument('-l', '--last', type=int, help='first image NOT to download', default=None)
+    parser.add_argument(
+        '-s',
+        '--size',
+        type=int,
+        default=DEFAULT_SIZE,
+        help='image size in pixel (0 means full size)',
+    )
+    parser.add_argument(
+        '-n',
+        '--nthreads',
+        type=int,
+        default=DEFAULT_N_THREADS,
+        help='max n. of threads',
+    )
+    parser.add_argument(
+        '-f',
+        '--first',
+        type=int,
+        default=0,
+        help='first image to download',
+    )
+    parser.add_argument(
+        '-l',
+        '--last',
+        type=int,
+        default=None,
+        help='first image NOT to download',
+    )
     parser.add_argument('-v', '--version', action='version', version=__version__)
     args = parser.parse_args()
 
-    # Initialize
-    downloader = AntenatiDownloader(args.url, args.first, args.last)
-
-    # Print gallery info
+    downloader = Downloader(args.url, args.first, args.last)
     downloader.print_gallery_info()
-
-    # Check if directory already exists and chdir to it
     downloader.check_dir()
-
-    # Run
-    gallery_size = downloader.run_cli(args.nthreads, args.size)
-
-    # Print summary
+    gallery_size = run_cli(downloader, args.nthreads, args.size)
     print(f'Done. Total size: {naturalsize(gallery_size, True)}')
 
 

--- a/antenati_downloader.py
+++ b/antenati_downloader.py
@@ -1,0 +1,144 @@
+"""Core download orchestration for the Portale Antenati.
+
+The :class:`Downloader` is the main entry point used by both the CLI
+(:mod:`antenati`) and the GUI (:mod:`antenati_gui`). It composes the
+side-effect free helpers from :mod:`antenati_iiif` with the HTTP session
+built in :mod:`antenati_http`, and runs the per-canvas image downloads in
+a thread pool.
+
+Keeping this orchestration in its own module makes it possible to embed
+the downloader from third-party scripts without depending on the CLI
+plumbing (``argparse``, ``click.confirm``, ``tqdm``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from json import loads
+from mimetypes import guess_extension
+from os import mkdir, path
+from pathlib import Path
+from sys import exit as sys_exit
+from typing import Any
+
+from click import confirm, echo
+from requests import Session
+from slugify import slugify
+
+import antenati_http
+import antenati_iiif
+from antenati_errors import ThreadError
+
+DEFAULT_SIZE: int = 0
+DEFAULT_N_THREADS: int = 2
+
+
+@dataclass
+class ProgressBar:
+    """Callback pair used to drive a progress indicator.
+
+    Both callbacks are invoked from the orchestrating thread, so simple
+    in-process counters are fine. GUIs that need to marshal updates onto
+    a UI thread should do so inside the ``update`` callback.
+    """
+
+    set_total: Callable[[int], None]
+    update: Callable[[], None]
+
+
+class Downloader:
+    """Download a Portale Antenati gallery to disk."""
+
+    url: str
+    session: Session
+    archive_id: str
+    manifest: dict[str, Any]
+    canvases: list[dict[str, Any]]
+    dirname: Path
+    gallery_length: int
+
+    def __init__(self, url: str, first: int, last: int | None):
+        self.url = url
+        self.session = antenati_http.build_session()
+        self.archive_id = antenati_iiif.get_archive_id_from_url(url)
+        self.manifest = self.__load_manifest()
+        self.canvases = antenati_iiif.slice_canvases(self.manifest, first, last)
+        self.dirname = self.__generate_dirname()
+        self.gallery_length = len(self.canvases)
+
+    def __load_manifest(self) -> dict[str, Any]:
+        gallery_reply = antenati_http.fetch(self.session, self.url)
+        gallery_charset = antenati_http.get_content_charset(gallery_reply) or 'utf-8'
+        gallery_html = gallery_reply.content.decode(gallery_charset)
+        manifest_url = antenati_iiif.parse_manifest_url_from_html(gallery_html, self.url)
+        manifest_reply = antenati_http.fetch(self.session, manifest_url)
+        manifest_charset = antenati_http.get_content_charset(manifest_reply) or 'utf-8'
+        return loads(manifest_reply.content.decode(manifest_charset))
+
+    def __generate_dirname(self) -> Path:
+        context = antenati_iiif.get_metadata_value(self.manifest, 'Contesto archivistico')
+        year = antenati_iiif.get_metadata_value(self.manifest, 'Titolo')
+        typology = antenati_iiif.get_metadata_value(self.manifest, 'Tipologia')
+        return Path(slugify(f'{context}-{year}-{typology}-{self.archive_id}'))
+
+    def print_gallery_info(self) -> None:
+        """Write the gallery's IIIF metadata to stdout."""
+        for entry in self.manifest['metadata']:
+            label = entry['label']
+            value = entry['value']
+            print(f'{label:<25}{value}')
+        print(f'{self.gallery_length} images found.')
+
+    def check_dir(self, parentdir: str | None = None, interactive: bool = True) -> None:
+        """Ensure the output directory exists, prompting the user on conflict."""
+        if parentdir is not None:
+            self.dirname = Path(parentdir) / self.dirname
+        print(f'Output directory: {self.dirname}')
+        if path.exists(self.dirname):
+            msg = f'Directory {self.dirname} already exists.'
+            if not interactive:
+                raise RuntimeError(msg)
+            echo(msg)
+            if not confirm('Do you want to proceed?'):
+                sys_exit(1)
+        else:
+            mkdir(self.dirname)
+
+    def __thread_main(self, canvas: dict[str, Any], size: int) -> int:
+        label = slugify(canvas['label'])
+        try:
+            image_url = antenati_iiif.image_url_for_canvas(canvas)
+            url = antenati_iiif.manipulate_image_url(image_url, size)
+            http_reply = antenati_http.fetch(self.session, url)
+            content_type = antenati_http.get_content_type(http_reply)
+            extension = guess_extension(content_type)
+            if not extension:
+                raise RuntimeError(f'{url}: Unable to guess extension "{content_type}"')
+            filename = self.dirname / f'{label}{extension}'
+            with open(filename, 'wb') as img_file:
+                img_file.write(http_reply.content)
+            return len(http_reply.content)
+        except Exception as ex:
+            raise ThreadError(label) from ex
+
+    def run(self, n_workers: int, size: int, progress: ProgressBar) -> int:
+        """Download all canvases concurrently. Returns total bytes written."""
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            future_img = {executor.submit(self.__thread_main, i, size) for i in self.canvases}
+            progress.set_total(self.gallery_length)
+            gallery_size = 0
+            failed: dict[str, str] = {}
+            for future in as_completed(future_img):
+                progress.update()
+                try:
+                    gallery_size += future.result()
+                except ThreadError as ex:
+                    failed[ex.label] = str(ex.__cause__)
+                    continue
+            if failed:
+                msg = f'Failed to download {len(failed)} images:\n'
+                msg += '\n - '.join(f'{k}: {v}' for k, v in failed.items())
+                raise RuntimeError(msg)
+            return gallery_size

--- a/antenati_errors.py
+++ b/antenati_errors.py
@@ -1,0 +1,35 @@
+"""Exception hierarchy for the antenati downloader.
+
+A single base ``AntenatiError`` lets callers catch any tool-specific error
+with one ``except`` while still allowing fine-grained handling. The
+``ManifestError`` and ``WafChallengeError`` subclasses are defined here
+ahead of the hardening PR that will start raising them in
+:mod:`antenati_iiif` and :mod:`antenati_http` -- existing call sites keep
+raising ``RuntimeError`` for now to preserve behaviour.
+"""
+
+from __future__ import annotations
+
+
+class AntenatiError(Exception):
+    """Base class for all antenati-specific errors."""
+
+
+class ManifestError(AntenatiError):
+    """The IIIF manifest is missing a required field or has an unexpected shape."""
+
+
+class WafChallengeError(AntenatiError):
+    """The SAN server returned an AWS WAF challenge response that cannot be bypassed."""
+
+
+class ThreadError(AntenatiError):
+    """Container used inside the download thread pool for exception chaining.
+
+    Wraps the original exception so the orchestrator can associate the
+    failure with a specific canvas label without losing the cause.
+    """
+
+    def __init__(self, label: str):
+        super().__init__(label)
+        self.label = label

--- a/antenati_http.py
+++ b/antenati_http.py
@@ -19,7 +19,6 @@ later refactor step.
 from __future__ import annotations
 
 from email.message import Message
-from typing import Optional
 
 from requests import Response, Session
 from requests.utils import default_headers
@@ -79,7 +78,7 @@ def get_content_type(reply: Response) -> str:
     return msg.get_content_type()
 
 
-def get_content_charset(reply: Response) -> Optional[str]:
+def get_content_charset(reply: Response) -> str | None:
     """Return the charset declared in a response's Content-Type, if any."""
     msg = Message()
     msg['Content-Type'] = reply.headers['Content-Type']

--- a/antenati_iiif.py
+++ b/antenati_iiif.py
@@ -14,7 +14,7 @@ will land in a dedicated PR with its own tests.
 from __future__ import annotations
 
 from re import findall, search
-from typing import Any, Optional
+from typing import Any
 
 # The gallery HTML embeds the IIIF manifest URL inside a JavaScript
 # ``manifestId = '<URL>'`` assignment. The character class below is what
@@ -79,7 +79,7 @@ def get_metadata_value(manifest: dict[str, Any], label: str) -> str:
         raise RuntimeError(f'Cannot get {label} from manifest') from exc
 
 
-def slice_canvases(manifest: dict[str, Any], first: int, last: Optional[int]) -> list[dict[str, Any]]:
+def slice_canvases(manifest: dict[str, Any], first: int, last: int | None) -> list[dict[str, Any]]:
     """Return ``manifest['sequences'][0]['canvases'][first:last]``.
 
     Encapsulating this single index access keeps the assumption (single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.ruff]
 line-length = 160
-target-version = "py39"
+target-version = "py310"
 extend-exclude = ["build", "dist"]
 
 [tool.ruff.lint]
@@ -14,42 +14,27 @@ extend-exclude = ["build", "dist"]
 # codebase. Stricter rules (PTH, ANN, D, etc.) will be turned on as the
 # refactor lands and the affected code is rewritten.
 select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF", "RET", "TID"]
-ignore = [
-    # Allow `Optional[...]` / `Union[...]` while still on Python 3.9.
-    "UP007",
-    "UP045",
-]
 
 [tool.ruff.lint.per-file-ignores]
-# Legacy single-file modules: relax style-only rules until they are split
-# into the new package layout in the refactor PRs. Real lint issues are
-# still enforced.
-"antenati.py" = ["UP034", "SIM108", "RET504"]
+# antenati_gui.py is the only file still untouched by the refactor; its
+# imports will be sorted when the GUI worker extraction lands.
 "antenati_gui.py" = ["I001"]
 
 [tool.ruff.format]
 quote-style = "single"
-# Legacy single-file modules will be reformatted in a dedicated PR once
-# they are split into the new package layout, to keep the diff for each
-# refactor PR readable.
-exclude = ["antenati.py", "antenati_gui.py"]
+# antenati_gui.py is reformatted in the GUI worker extraction PR.
+exclude = ["antenati_gui.py"]
 
 [tool.mypy]
-# mypy 1.19+ no longer supports type-checking against Python 3.9. The code
-# itself still targets py39 (see ruff's target-version) and is verified to
-# import on 3.9 in CI; type narrowing just gets analysed as if running on
-# 3.10. Bump this in sync with the runtime minimum if/when 3.9 is dropped.
 python_version = "3.10"
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unreachable = true
 check_untyped_defs = true
 
-# Legacy single-file modules: keep mypy importing them without enforcing
-# strict checks until they are split into the new package layout. Strict
-# mode will then be enabled module-by-module in the refactor PRs.
+# antenati_gui.py keeps a relaxed override until the worker refactor.
 [[tool.mypy.overrides]]
-module = ["antenati", "antenati_gui"]
+module = ["antenati_gui"]
 ignore_errors = true
 
 [tool.pytest.ini_options]

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -166,7 +166,7 @@ def test_run_cli_uses_tqdm_progress_bar(mocked_http, downloader_in_tmp: Antenati
             status=200,
             content_type='image/jpeg',
         )
-    total = downloader_in_tmp.run_cli(n_workers=2, size=0)
+    total = antenati.run_cli(downloader_in_tmp, n_workers=2, size=0)
     assert total == 3 * len(TINY_JPEG)
 
 


### PR DESCRIPTION
- antenati_downloader.py: Downloader (the class formerly known as AntenatiDownloader), ProgressBar dataclass and DEFAULT_* constants live here. The orchestration logic now uses antenati_http and antenati_iiif exclusively, so the module is GUI-friendly (no argparse, click or tqdm dependencies).
- antenati_errors.py: AntenatiError base + ManifestError / WafChallengeError subclasses introduced ahead of the hardening PR, plus ThreadError relocated from antenati.py.
- antenati.py: collapses to the CLI surface (argparse + main()) plus backward-compatible re-exports. `AntenatiDownloader` is now a public alias for `Downloader`; the GUI and any external scripts keep working unchanged. `run_cli` becomes a module-level helper instead of a Downloader method (it depends on tqdm, which the Downloader shouldn't).

Python 3.10 baseline:
- README: bumped declared requirement.
- ruff target-version: py310; the UP007/UP045 ignores for Optional are removed, switching annotations to `X | None`.
- The legacy per-file-ignores and the `antenati` mypy override are gone now that antenati.py is rewritten. antenati_gui.py keeps its relaxed override pending the GUI worker refactor.

Side effect of mypy strictness on the new module: a latent None-charset issue (silent fallback only on Antenati's well-behaved server) is now handled explicitly with `or 'utf-8'` -- semantically equivalent to `bytes.decode()`'s default.

Tests:
- One test updated (`test_run_cli_uses_tqdm_progress_bar`) to call the new module-level `antenati.run_cli`. All 45 offline tests pass.