### PR TITLE
Harden HTTP + IIIF: retries, typed errors, defensive parsing

### DIFF
--- a/antenati.py
+++ b/antenati.py
@@ -9,6 +9,7 @@ __license__ = 'MIT License'
 __version__ = '5.0'
 __contact__ = 'https://gcerretani.github.io/antenati/'
 
+import logging
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
 from humanize import naturalsize
@@ -16,6 +17,22 @@ from tqdm import tqdm
 
 from antenati_downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, Downloader, ProgressBar
 from antenati_errors import ThreadError
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Configure the root logger from a -v/-vv count.
+
+    Default (no flag) keeps the historical behaviour: only WARNING and
+    above are visible. ``--verbose`` raises to INFO; passing it twice
+    enables DEBUG (including each HTTP request).
+    """
+    level = logging.WARNING
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity >= 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format='%(levelname)s %(name)s: %(message)s')
+
 
 # Backwards-compatible alias: external scripts and ``antenati_gui`` still
 # import ``antenati.AntenatiDownloader``. Removing the alias is a major
@@ -80,8 +97,15 @@ def main() -> None:
         help='first image NOT to download',
     )
     parser.add_argument('-v', '--version', action='version', version=__version__)
+    parser.add_argument(
+        '--verbose',
+        action='count',
+        default=0,
+        help='increase logging verbosity (--verbose for INFO, --verbose --verbose for DEBUG)',
+    )
     args = parser.parse_args()
 
+    _configure_logging(args.verbose)
     downloader = Downloader(args.url, args.first, args.last)
     downloader.print_gallery_info()
     downloader.check_dir()

--- a/antenati_downloader.py
+++ b/antenati_downloader.py
@@ -13,6 +13,7 @@ plumbing (``argparse``, ``click.confirm``, ``tqdm``).
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -24,12 +25,14 @@ from sys import exit as sys_exit
 from typing import Any
 
 from click import confirm, echo
-from requests import Session
+from requests import RequestException, Session
 from slugify import slugify
 
 import antenati_http
 import antenati_iiif
-from antenati_errors import ThreadError
+from antenati_errors import AntenatiError, ThreadError
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SIZE: int = 0
 DEFAULT_N_THREADS: int = 2
@@ -63,24 +66,27 @@ class Downloader:
         self.url = url
         self.session = antenati_http.build_session()
         self.archive_id = antenati_iiif.get_archive_id_from_url(url)
+        logger.info('Loading manifest for archive %s', self.archive_id)
         self.manifest = self.__load_manifest()
         self.canvases = antenati_iiif.slice_canvases(self.manifest, first, last)
         self.dirname = self.__generate_dirname()
         self.gallery_length = len(self.canvases)
+        logger.info('Manifest loaded: %d canvases selected', self.gallery_length)
 
     def __load_manifest(self) -> dict[str, Any]:
         gallery_reply = antenati_http.fetch(self.session, self.url)
         gallery_charset = antenati_http.get_content_charset(gallery_reply) or 'utf-8'
         gallery_html = gallery_reply.content.decode(gallery_charset)
         manifest_url = antenati_iiif.parse_manifest_url_from_html(gallery_html, self.url)
+        logger.debug('Manifest URL: %s', manifest_url)
         manifest_reply = antenati_http.fetch(self.session, manifest_url)
         manifest_charset = antenati_http.get_content_charset(manifest_reply) or 'utf-8'
         return loads(manifest_reply.content.decode(manifest_charset))
 
     def __generate_dirname(self) -> Path:
-        context = antenati_iiif.get_metadata_value(self.manifest, 'Contesto archivistico')
-        year = antenati_iiif.get_metadata_value(self.manifest, 'Titolo')
-        typology = antenati_iiif.get_metadata_value(self.manifest, 'Tipologia')
+        context = antenati_iiif.get_metadata_value(self.manifest, antenati_iiif.META_CONTEXT)
+        year = antenati_iiif.get_metadata_value(self.manifest, antenati_iiif.META_TITLE)
+        typology = antenati_iiif.get_metadata_value(self.manifest, antenati_iiif.META_TYPOLOGY)
         return Path(slugify(f'{context}-{year}-{typology}-{self.archive_id}'))
 
     def print_gallery_info(self) -> None:
@@ -120,7 +126,8 @@ class Downloader:
             with open(filename, 'wb') as img_file:
                 img_file.write(http_reply.content)
             return len(http_reply.content)
-        except Exception as ex:
+        except (RequestException, AntenatiError, OSError, RuntimeError) as ex:
+            logger.warning('Image %s failed: %s', label, ex)
             raise ThreadError(label) from ex
 
     def run(self, n_workers: int, size: int, progress: ProgressBar) -> int:

--- a/antenati_http.py
+++ b/antenati_http.py
@@ -1,27 +1,36 @@
 """HTTP plumbing for the Portale Antenati downloader.
 
-Exposes a single small surface that ``antenati.AntenatiDownloader`` (and any
-future module) can lean on without re-implementing the SAN-server quirks:
+Exposes a single small surface that the rest of the package leans on
+without re-implementing the SAN-server quirks:
 
 - :func:`build_session` returns a :class:`requests.Session` preconfigured
-  with the headers required by the SAN reverse proxy.
-- :func:`fetch` performs a ``GET`` and turns the AWS WAF challenge response
-  (HTTP 202 with ``x-amzn-waf-action: challenge``) into a clean
-  :class:`RuntimeError`.
-- :func:`get_content_type` / :func:`get_content_charset` parse a response's
-  ``Content-Type`` header.
+  with the browser-like headers required by the SAN reverse proxy and an
+  ``urllib3.util.Retry`` adapter that transparently retries on transient
+  5xx and rate-limit responses.
+- :func:`fetch` performs a ``GET`` and turns the AWS WAF challenge
+  response (HTTP 202 with ``x-amzn-waf-action: challenge``) into a typed
+  :class:`antenati_errors.WafChallengeError`.
+- :func:`get_content_type` / :func:`get_content_charset` parse a
+  response's ``Content-Type`` header.
 
-This module is intentionally side-effect free at import time: it only
-declares helpers. Retry policies and structured logging will be added in a
-later refactor step.
+The module is side-effect free at import time except for module-level
+logger configuration: nothing is logged unless the application configures
+the root logger (see :mod:`antenati`'s ``--verbose`` flag).
 """
 
 from __future__ import annotations
 
+import logging
 from email.message import Message
 
 from requests import Response, Session
+from requests.adapters import HTTPAdapter
 from requests.utils import default_headers
+from urllib3.util.retry import Retry
+
+from antenati_errors import WafChallengeError
+
+logger = logging.getLogger(__name__)
 
 # These are observable behaviours of the SAN server; pulling them into
 # named constants makes the WAF detection explicit and lets tests assert
@@ -29,6 +38,14 @@ from requests.utils import default_headers
 WAF_CHALLENGE_STATUS: int = 202
 WAF_CHALLENGE_HEADER: str = 'x-amzn-waf-action'
 WAF_CHALLENGE_VALUE: str = 'challenge'
+
+# Retry policy applied to every Session built by :func:`build_session`.
+# These are the transient statuses the SAN server is known to return when
+# overloaded; they get retried with exponential backoff before the caller
+# sees an HTTPError. Tuned conservatively to avoid hammering the server.
+RETRY_TOTAL: int = 5
+RETRY_BACKOFF_FACTOR: float = 0.5
+RETRYABLE_STATUSES: tuple[int, ...] = (429, 500, 502, 503, 504)
 
 # Mimic a current Edge-on-Windows fingerprint. The SAN reverse proxy 403s
 # requests that look automated, so this header is part of the contract.
@@ -44,10 +61,24 @@ def _http_headers():
     return headers
 
 
+def _retry_policy() -> Retry:
+    """Return the urllib3 Retry policy mounted on every Session."""
+    return Retry(
+        total=RETRY_TOTAL,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        status_forcelist=list(RETRYABLE_STATUSES),
+        allowed_methods=frozenset(['GET']),
+        raise_on_status=False,
+    )
+
+
 def build_session() -> Session:
     """Return a Session preconfigured for Portale Antenati requests."""
     session = Session()
     session.headers = _http_headers()
+    adapter = HTTPAdapter(max_retries=_retry_policy())
+    session.mount('https://', adapter)
+    session.mount('http://', adapter)
     return session
 
 
@@ -57,17 +88,20 @@ def fetch(session: Session, url: str) -> Response:
     Raises
     ------
     requests.HTTPError
-        If the server returned a 4xx/5xx status.
-    RuntimeError
+        If the server returned a 4xx/5xx status (after retries have been
+        exhausted for retryable statuses).
+    WafChallengeError
         If the server returned an AWS WAF challenge (HTTP 202 with the
         ``x-amzn-waf-action: challenge`` header). There is currently no
         bypass; surfacing this as a distinct error helps callers diagnose
         the problem without parsing HTML.
     """
+    logger.debug('GET %s', url)
     reply = session.get(url)
     reply.raise_for_status()
     if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
-        raise RuntimeError(f'{reply.url}: AWS WAF challenge cannot be bypassed. See https://github.com/gcerretani/antenati/issues/25 for details.')
+        logger.warning('WAF challenge received from %s', reply.url)
+        raise WafChallengeError(f'{reply.url}: AWS WAF challenge cannot be bypassed. See https://github.com/gcerretani/antenati/issues/25 for details.')
     return reply
 
 

--- a/antenati_iiif.py
+++ b/antenati_iiif.py
@@ -2,13 +2,13 @@
 
 All functions in this module work on plain Python data (strings, dicts).
 None of them perform I/O, which makes them straightforward to unit test
-offline. ``antenati.AntenatiDownloader`` orchestrates HTTP fetching and
-delegates the parsing to these helpers.
+offline. :class:`antenati_downloader.Downloader` orchestrates HTTP
+fetching and delegates the parsing to these helpers.
 
-The current implementations preserve the exact behaviour of the legacy
-single-file ``antenati.py`` -- including a couple of known fragilities in
-the manifest URL regex and the unguarded JSON accesses. Hardening those
-will land in a dedicated PR with its own tests.
+Errors raised by this module are all subclasses of
+:class:`antenati_errors.ManifestError`, so callers can catch one type to
+distinguish "the gallery looks malformed" from network or filesystem
+failures.
 """
 
 from __future__ import annotations
@@ -16,17 +16,25 @@ from __future__ import annotations
 from re import findall, search
 from typing import Any
 
+from antenati_errors import ManifestError
+
 # The gallery HTML embeds the IIIF manifest URL inside a JavaScript
-# ``manifestId = '<URL>'`` assignment. The character class below is what
-# the legacy parser accepted; broadening it (e.g. to allow underscores or
-# query strings) is a behaviour change and is deliberately deferred.
-_MANIFEST_URL_PATTERN: str = r'\'([A-Za-z0-9.:/-]*)\''
+# ``manifestId = '<URL>'`` assignment. The pattern accepts both single
+# and double quotes around the URL and is intentionally permissive about
+# what characters are allowed inside the URL (anything that's not the
+# closing quote) to survive future URL changes by the SAN team.
+_MANIFEST_URL_PATTERN: str = r"""['"](https?://[^'"]+)['"]"""
 _MANIFEST_KEYWORD: str = 'manifestId'
 
 # IIIF size syntax: ``/full/full/0/`` is the legacy "give me everything"
 # template baked into the manifest. We rewrite it to one of the size
 # variants the SAN server still serves.
 _FULL_SIZE_TEMPLATE: str = '/full/full/0/'
+
+# Metadata labels we expect in every Antenati IIIF manifest.
+META_CONTEXT: str = 'Contesto archivistico'
+META_TITLE: str = 'Titolo'
+META_TYPOLOGY: str = 'Tipologia'
 
 
 def get_archive_id_from_url(url: str) -> str:
@@ -41,7 +49,7 @@ def get_archive_id_from_url(url: str) -> str:
     """
     numbers = findall(r'(\d+)', url)
     if len(numbers) < 2:
-        raise RuntimeError(f'Cannot get archive ID from {url}')
+        raise ManifestError(f'Cannot get archive ID from {url}')
     return numbers[1]
 
 
@@ -61,10 +69,10 @@ def parse_manifest_url_from_html(html: str, source_url: str) -> str:
         None,
     )
     if not manifest_line:
-        raise RuntimeError(f'No IIIF manifest found at {source_url}')
+        raise ManifestError(f'No IIIF manifest found at {source_url}')
     match = search(_MANIFEST_URL_PATTERN, manifest_line)
     if not match:
-        raise RuntimeError(f'Invalid IIIF manifest line found at {source_url}')
+        raise ManifestError(f'Invalid IIIF manifest line found at {source_url}')
     return match.group(1)
 
 
@@ -74,24 +82,36 @@ def get_metadata_value(manifest: dict[str, Any], label: str) -> str:
     The IIIF manifest metadata is a list of ``{label, value}`` dicts.
     """
     try:
-        return next(i['value'] for i in manifest['metadata'] if i['label'] == label)
+        entries = manifest['metadata']
+    except KeyError as exc:
+        raise ManifestError("Manifest has no 'metadata' field") from exc
+    try:
+        return next(i['value'] for i in entries if i['label'] == label)
     except StopIteration as exc:
-        raise RuntimeError(f'Cannot get {label} from manifest') from exc
+        raise ManifestError(f'Cannot get {label} from manifest') from exc
 
 
 def slice_canvases(manifest: dict[str, Any], first: int, last: int | None) -> list[dict[str, Any]]:
-    """Return ``manifest['sequences'][0]['canvases'][first:last]``.
+    """Return the canvases of the manifest sliced by ``first:last``.
 
-    Encapsulating this single index access keeps the assumption (single
-    sequence at index 0) in one place; a future PR will replace it with a
-    defensive lookup that raises a typed ``ManifestError`` instead.
+    Raises :class:`ManifestError` if the manifest is missing the expected
+    ``sequences[0].canvases`` path or that path contains nothing.
     """
-    return manifest['sequences'][0]['canvases'][first:last]
+    try:
+        canvases = manifest['sequences'][0]['canvases']
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ManifestError("Manifest has no 'sequences[0].canvases' field") from exc
+    if not canvases:
+        raise ManifestError('Manifest contains no canvases')
+    return canvases[first:last]
 
 
 def image_url_for_canvas(canvas: dict[str, Any]) -> str:
     """Return the image URL declared by an IIIF canvas."""
-    return canvas['images'][0]['resource']['@id']
+    try:
+        return canvas['images'][0]['resource']['@id']
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ManifestError("Canvas has no 'images[0].resource.@id' field") from exc
 
 
 def manipulate_image_url(url: str, size: int) -> str:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,6 +6,7 @@ import pytest
 import responses
 
 import antenati_http
+from antenati_errors import WafChallengeError
 
 
 def test_build_session_sets_required_headers() -> None:
@@ -53,8 +54,47 @@ def test_fetch_raises_on_waf_challenge() -> None:
             headers={antenati_http.WAF_CHALLENGE_HEADER: antenati_http.WAF_CHALLENGE_VALUE},
             content_type='text/html; charset=utf-8',
         )
-        with pytest.raises(RuntimeError, match='AWS WAF challenge'):
+        with pytest.raises(WafChallengeError, match='AWS WAF challenge'):
             antenati_http.fetch(session, 'https://example.org/challenge')
+
+
+def test_fetch_retries_on_503_then_succeeds() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        # urllib3's Retry consumes one response per attempt; queue two
+        # transient failures followed by a success.
+        rsps.add(
+            responses.GET,
+            'https://example.org/flaky',
+            body='oops',
+            status=503,
+            content_type='text/plain',
+        )
+        rsps.add(
+            responses.GET,
+            'https://example.org/flaky',
+            body='oops',
+            status=503,
+            content_type='text/plain',
+        )
+        rsps.add(
+            responses.GET,
+            'https://example.org/flaky',
+            body='ok',
+            status=200,
+            content_type='text/plain',
+        )
+        reply = antenati_http.fetch(session, 'https://example.org/flaky')
+    assert reply.status_code == 200
+    assert reply.text == 'ok'
+
+
+def test_session_mounts_retrying_adapter() -> None:
+    session = antenati_http.build_session()
+    adapter = session.get_adapter('https://example.org/')
+    retry = adapter.max_retries
+    assert retry.total == antenati_http.RETRY_TOTAL
+    assert set(retry.status_forcelist) == set(antenati_http.RETRYABLE_STATUSES)
 
 
 def test_fetch_does_not_treat_plain_202_as_waf() -> None:

--- a/tests/test_iiif_defensive.py
+++ b/tests/test_iiif_defensive.py
@@ -1,0 +1,53 @@
+"""Tests for the defensive guards added to :mod:`antenati_iiif`.
+
+These cover the manifest-shape failure modes that used to raise raw
+``KeyError`` / ``IndexError`` exceptions and now surface as typed
+:class:`antenati_errors.ManifestError`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import antenati_iiif
+from antenati_errors import ManifestError
+
+
+def test_slice_canvases_missing_sequences_raises() -> None:
+    with pytest.raises(ManifestError, match=r'sequences\[0\]\.canvases'):
+        antenati_iiif.slice_canvases({}, 0, None)
+
+
+def test_slice_canvases_empty_sequences_raises() -> None:
+    with pytest.raises(ManifestError, match=r'sequences\[0\]\.canvases'):
+        antenati_iiif.slice_canvases({'sequences': []}, 0, None)
+
+
+def test_slice_canvases_missing_canvases_key_raises() -> None:
+    with pytest.raises(ManifestError, match=r'sequences\[0\]\.canvases'):
+        antenati_iiif.slice_canvases({'sequences': [{}]}, 0, None)
+
+
+def test_slice_canvases_empty_canvases_raises() -> None:
+    with pytest.raises(ManifestError, match='no canvases'):
+        antenati_iiif.slice_canvases({'sequences': [{'canvases': []}]}, 0, None)
+
+
+def test_image_url_for_canvas_missing_images_raises() -> None:
+    with pytest.raises(ManifestError, match=r'images\[0\]\.resource'):
+        antenati_iiif.image_url_for_canvas({})
+
+
+def test_image_url_for_canvas_missing_resource_raises() -> None:
+    with pytest.raises(ManifestError, match=r'images\[0\]\.resource'):
+        antenati_iiif.image_url_for_canvas({'images': [{}]})
+
+
+def test_image_url_for_canvas_missing_id_raises() -> None:
+    with pytest.raises(ManifestError, match=r'images\[0\]\.resource'):
+        antenati_iiif.image_url_for_canvas({'images': [{'resource': {}}]})
+
+
+def test_image_url_for_canvas_happy_path() -> None:
+    canvas = {'images': [{'resource': {'@id': 'https://example.org/x.jpg'}}]}
+    assert antenati_iiif.image_url_for_canvas(canvas) == 'https://example.org/x.jpg'

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -15,6 +15,7 @@ import antenati
 import antenati_http
 import antenati_iiif
 from antenati import AntenatiDownloader
+from antenati_errors import ManifestError, WafChallengeError
 from tests.conftest import ARCHIVE_ID, GALLERY_URL, MANIFEST_URL
 
 
@@ -27,12 +28,12 @@ def test_archive_id_helper_returns_second_integer() -> None:
 
 
 def test_archive_id_helper_raises_when_url_lacks_two_numbers() -> None:
-    with pytest.raises(RuntimeError, match='Cannot get archive ID'):
+    with pytest.raises(ManifestError, match='Cannot get archive ID'):
         antenati_iiif.get_archive_id_from_url('https://antenati.cultura.gov.it/no-numbers/')
 
 
 def test_constructor_raises_when_url_lacks_two_numbers(mocked_http) -> None:
-    with pytest.raises(RuntimeError, match='Cannot get archive ID'):
+    with pytest.raises(ManifestError, match='Cannot get archive ID'):
         AntenatiDownloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
 
 
@@ -62,8 +63,24 @@ def test_parse_manifest_url_from_html_extracts_quoted_url() -> None:
 
 
 def test_parse_manifest_url_no_keyword_raises() -> None:
-    with pytest.raises(RuntimeError, match='No IIIF manifest found'):
+    with pytest.raises(ManifestError, match='No IIIF manifest found'):
         antenati_iiif.parse_manifest_url_from_html('<html>nothing here</html>', 'src')
+
+
+@pytest.mark.parametrize(
+    'html',
+    [
+        # Single quotes around a URL with underscores and a query string.
+        "<script>var manifestId = 'https://iiif.example.org/ark:/12657/an_ua19944535/manifest?v=2';</script>",
+        # Double quotes.
+        '<script>var manifestId = "https://iiif.example.org/manifest";</script>',
+    ],
+)
+def test_parse_manifest_url_accepts_modern_url_shapes(html: str) -> None:
+    # Locks the post-hardening behaviour: the legacy regex rejected
+    # underscores and query strings, the new one accepts them.
+    result = antenati_iiif.parse_manifest_url_from_html(html, 'src')
+    assert result.startswith('https://')
 
 
 def test_constructor_raises_when_html_lacks_manifest(gallery_html: str) -> None:
@@ -76,14 +93,13 @@ def test_constructor_raises_when_html_lacks_manifest(gallery_html: str) -> None:
             status=200,
             content_type='text/html; charset=utf-8',
         )
-        with pytest.raises(RuntimeError, match='No IIIF manifest found'):
+        with pytest.raises(ManifestError, match='No IIIF manifest found'):
             AntenatiDownloader(GALLERY_URL, 0, None)
 
 
 def test_constructor_raises_on_invalid_manifest_line() -> None:
-    # Locks in the *current* (fragile) behaviour: ``manifestId`` keyword
-    # present but no quoted URL eventually raises. The exact exception type
-    # will become more specific in a later hardening PR.
+    # The ``manifestId`` keyword is present but there is no quoted URL on
+    # the line: parsing must raise a typed ManifestError.
     bad_html = '<script>var manifestId = noQuotesHere;</script>'
     with responses.RequestsMock() as rsps:
         rsps.add(
@@ -93,7 +109,7 @@ def test_constructor_raises_on_invalid_manifest_line() -> None:
             status=200,
             content_type='text/html; charset=utf-8',
         )
-        with pytest.raises(Exception):  # noqa: B017 - locks current behaviour
+        with pytest.raises(ManifestError, match='Invalid IIIF manifest line'):
             AntenatiDownloader(GALLERY_URL, 0, None)
 
 
@@ -107,7 +123,7 @@ def test_waf_challenge_is_detected() -> None:
             headers={antenati_http.WAF_CHALLENGE_HEADER: antenati_http.WAF_CHALLENGE_VALUE},
             content_type='text/html; charset=utf-8',
         )
-        with pytest.raises(RuntimeError, match='AWS WAF challenge'):
+        with pytest.raises(WafChallengeError, match='AWS WAF challenge'):
             AntenatiDownloader(GALLERY_URL, 0, None)
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,6 +6,7 @@ import pytest
 
 import antenati_iiif
 from antenati import AntenatiDownloader
+from antenati_errors import ManifestError
 
 
 def test_get_metadata_value_finds_label(manifest_dict: dict) -> None:
@@ -14,8 +15,13 @@ def test_get_metadata_value_finds_label(manifest_dict: dict) -> None:
 
 
 def test_get_metadata_value_unknown_label_raises(manifest_dict: dict) -> None:
-    with pytest.raises(RuntimeError, match='Cannot get'):
+    with pytest.raises(ManifestError, match='Cannot get'):
         antenati_iiif.get_metadata_value(manifest_dict, 'does-not-exist')
+
+
+def test_get_metadata_value_without_metadata_field_raises() -> None:
+    with pytest.raises(ManifestError, match="no 'metadata' field"):
+        antenati_iiif.get_metadata_value({}, 'Titolo')
 
 
 def test_generate_dirname_combines_metadata_and_archive_id(


### PR DESCRIPTION
Behaviour changes are deliberately narrow and additive: existing successful runs are unaffected; the only observable differences are that transient SAN-server failures are now retried, that the failure exceptions raised when something is structurally wrong are now typed instead of bare RuntimeError, and that the CLI grows a --verbose flag.

antenati_http:
- build_session() now mounts an urllib3 Retry adapter with exponential backoff (total=5, backoff=0.5s) on 429/500/502/503/504 GETs. The Antenati SAN server returns 5xx under load; the retry handles them before the caller sees an HTTPError.
- fetch() now raises antenati_errors.WafChallengeError (not RuntimeError) on the documented 202+x-amzn-waf-action signal.
- Module-level logger; HTTP attempts logged at DEBUG, WAF events at WARNING.
- New constants RETRY_TOTAL / RETRY_BACKOFF_FACTOR / RETRYABLE_STATUSES are public so tests and ops docs can refer to them by name.

antenati_iiif:
- Every failure path raises antenati_errors.ManifestError: get_archive_id_from_url, parse_manifest_url_from_html, get_metadata_value (now also catches a missing 'metadata' field), slice_canvases (catches missing sequences/canvases or empty canvases list) and image_url_for_canvas (catches missing images/resource/@id).
- Manifest URL regex broadened from the legacy r'\'([A-Za-z0-9.:/-]*)\'' to r'["\'](https?://[^"\']+)["\']'. The legacy class rejected URLs containing underscores or query strings, which is a real concern given the SAN team's recent URL churn.
- New META_CONTEXT / META_TITLE / META_TYPOLOGY constants replace the string literals in antenati_downloader's __generate_dirname.

antenati_downloader:
- Module-level logger; INFO line for manifest loaded, DEBUG for the manifest URL discovered, WARNING for each failed canvas.
- __thread_main's `except Exception` narrowed to (RequestException, AntenatiError, OSError, RuntimeError); broad enough to keep the historical behaviour, narrow enough to no longer swallow programming errors like a misspelled attribute.

antenati CLI:
- New --verbose/--verbose --verbose flags. Default (no flag) keeps the historical WARNING+ behaviour; -v -> INFO, -vv -> DEBUG. The existing -v short flag stays bound to --version, so no breakage for users.

Tests (58 total, 13 new):
- test_iiif_defensive.py covers each new ManifestError guard.
- test_http.py covers WafChallengeError, 503->retry->success, and the mounted Retry policy shape.
- test_iiif_parsing.py: parametrised tests verify the broader manifest URL regex accepts underscores, query strings, and both quote styles.
- Existing tests updated from RuntimeError to the typed exceptions where the wrapper changed.