### PR TITLE
Deprecate AntenatiDownloader alias and update tests for Downloader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,7 @@ jobs:
     - name: Install package + dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-        pip install -e .
+        pip install -e ".[dev]"
 
     - name: Ruff check
       run: ruff check .
@@ -69,8 +68,7 @@ jobs:
     - name: Install package + dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-        pip install -e .
+        pip install -e ".[dev]"
 
     - name: Run offline test suite
       run: pytest -m "not integration"

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -32,8 +32,7 @@ jobs:
     - name: Install package + test dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-        pip install -e .
+        pip install -e ".[dev]"
 
     - name: Run integration tests against the live API
       run: pytest -m integration -v

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv (not the project's package manager — only used ad-hoc locally)
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,17 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+# Pinned dev tooling. Install with: pip install -e ".[dev]"
+dev = [
+    "mypy==1.19.1",
+    "pre-commit",
+    "pytest==9.0.3",
+    "responses==0.25.8",
+    "ruff==0.15.8",
+    "types-requests",
+]
+
 [project.urls]
 Homepage = "https://gcerretani.github.io/antenati/"
 Repository = "https://github.com/gcerretani/antenati"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-# Development dependencies. Runtime deps live in requirements.txt.
-# Install with:
-#   pip install -r requirements.txt -r requirements-dev.txt
-ruff==0.15.8
-mypy==1.19.1
-pytest==9.0.3
-responses==0.25.8
-types-requests
-pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-click~=8.3.0
-python-slugify~=8.0.4
-humanize~=4.14.0
-tqdm~=4.67.1
-requests~=2.32.5

--- a/src/antenati/__init__.py
+++ b/src/antenati/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from importlib.metadata import PackageNotFoundError, version
 
 __author__ = 'Giovanni Cerretani'
@@ -25,16 +26,9 @@ from antenati.downloader import (
 )
 from antenati.errors import ThreadError
 
-# Backwards-compatible alias for callers (notably any external script and
-# the historical ``import antenati; antenati.AntenatiDownloader`` shape).
-# Removing the alias is a major version bump scheduled for a later
-# cleanup PR.
-AntenatiDownloader = Downloader
-
 __all__ = [
     'DEFAULT_N_THREADS',
     'DEFAULT_SIZE',
-    'AntenatiDownloader',
     'Downloader',
     'ProgressBar',
     'ThreadError',
@@ -44,3 +38,14 @@ __all__ = [
     '__license__',
     '__version__',
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == 'AntenatiDownloader':
+        warnings.warn(
+            'AntenatiDownloader is deprecated and will be removed in v7.0; use antenati.Downloader instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return Downloader
+    raise AttributeError(f"module 'antenati' has no attribute {name!r}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 The HTML and IIIF JSON fixtures under ``tests/fixtures/`` mirror the shape
 of the responses served by the real Portale Antenati but contain no real
 data. They let us exercise the parsing, URL manipulation and download
-orchestration of ``AntenatiDownloader`` entirely offline.
+orchestration of :class:`antenati.Downloader` entirely offline.
 """
 
 from __future__ import annotations
@@ -73,6 +73,6 @@ def mocked_http(gallery_html: str, manifest_text: str):
 
 
 @pytest.fixture
-def downloader(mocked_http) -> antenati.AntenatiDownloader:
-    """Build an AntenatiDownloader against the mocked gallery+manifest."""
-    return antenati.AntenatiDownloader(GALLERY_URL, first=0, last=None)
+def downloader(mocked_http) -> antenati.Downloader:
+    """Build a Downloader against the mocked gallery+manifest."""
+    return antenati.Downloader(GALLERY_URL, first=0, last=None)

--- a/tests/test_check_dir.py
+++ b/tests/test_check_dir.py
@@ -1,4 +1,4 @@
-"""Tests for ``AntenatiDownloader.check_dir`` filesystem behaviour."""
+"""Tests for ``Downloader.check_dir`` filesystem behaviour."""
 
 from __future__ import annotations
 
@@ -6,23 +6,23 @@ from pathlib import Path
 
 import pytest
 
-from antenati import AntenatiDownloader
+from antenati import Downloader
 
 
-def test_check_dir_creates_target_under_parent(downloader: AntenatiDownloader, tmp_path: Path) -> None:
+def test_check_dir_creates_target_under_parent(downloader: Downloader, tmp_path: Path) -> None:
     downloader.check_dir(parentdir=str(tmp_path), interactive=False)
     assert downloader.dirname.is_dir()
     assert downloader.dirname.parent == tmp_path
 
 
-def test_check_dir_raises_when_target_exists_and_non_interactive(downloader: AntenatiDownloader, tmp_path: Path) -> None:
+def test_check_dir_raises_when_target_exists_and_non_interactive(downloader: Downloader, tmp_path: Path) -> None:
     target = tmp_path / str(downloader.dirname)
     target.mkdir()
     with pytest.raises(RuntimeError, match='already exists'):
         downloader.check_dir(parentdir=str(tmp_path), interactive=False)
 
 
-def test_check_dir_without_parent_uses_cwd(downloader: AntenatiDownloader, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_check_dir_without_parent_uses_cwd(downloader: Downloader, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     downloader.check_dir(interactive=False)
     assert (tmp_path / downloader.dirname).is_dir()

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for ``AntenatiDownloader.run`` with mocked HTTP.
+"""End-to-end tests for ``Downloader.run`` with mocked HTTP.
 
 These tests are the main safety net: they exercise the full happy path
 (gallery -> manifest -> per-image download -> filesystem writes) and a few
@@ -14,7 +14,7 @@ import pytest
 import responses
 
 import antenati
-from antenati import AntenatiDownloader, ProgressBar
+from antenati import Downloader, ProgressBar
 from antenati import cli as antenati_cli
 from tests.conftest import GALLERY_URL, TINY_JPEG
 
@@ -31,12 +31,12 @@ def _image_url(canvas_label: str, size: int) -> str:
 
 
 @pytest.fixture
-def downloader_in_tmp(downloader: AntenatiDownloader, tmp_path: Path) -> AntenatiDownloader:
+def downloader_in_tmp(downloader: Downloader, tmp_path: Path) -> Downloader:
     downloader.check_dir(parentdir=str(tmp_path), interactive=False)
     return downloader
 
 
-def test_run_downloads_all_images_full_size(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_downloads_all_images_full_size(mocked_http, downloader_in_tmp: Downloader) -> None:
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
             responses.GET,
@@ -51,7 +51,7 @@ def test_run_downloads_all_images_full_size(mocked_http, downloader_in_tmp: Ante
     assert files == ['0001.jpg', '0002.jpg', '0003.jpg']
 
 
-def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: Downloader) -> None:
     size = 1234
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
@@ -65,7 +65,7 @@ def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: Antenati
     assert total == 3 * len(TINY_JPEG)
 
 
-def test_run_partial_failure_raises_with_summary(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_partial_failure_raises_with_summary(mocked_http, downloader_in_tmp: Downloader) -> None:
     # First image succeeds, second 500s, third succeeds.
     mocked_http.add(
         responses.GET,
@@ -92,7 +92,7 @@ def test_run_partial_failure_raises_with_summary(mocked_http, downloader_in_tmp:
         downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
 
 
-def test_run_progress_callbacks_are_invoked(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_progress_callbacks_are_invoked(mocked_http, downloader_in_tmp: Downloader) -> None:
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
             responses.GET,
@@ -116,7 +116,7 @@ def test_run_progress_callbacks_are_invoked(mocked_http, downloader_in_tmp: Ante
 def test_run_filename_uses_image_extension(mocked_http, tmp_path: Path) -> None:
     # Construct a downloader with a single canvas served as PNG so we can
     # observe ``guess_extension`` picking up a different extension.
-    dl = AntenatiDownloader(GALLERY_URL, first=0, last=1)
+    dl = Downloader(GALLERY_URL, first=0, last=1)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
     mocked_http.add(
         responses.GET,
@@ -130,7 +130,7 @@ def test_run_filename_uses_image_extension(mocked_http, tmp_path: Path) -> None:
 
 
 def test_run_with_first_last_range_downloads_subset(mocked_http, tmp_path: Path) -> None:
-    dl = AntenatiDownloader(GALLERY_URL, first=1, last=3)
+    dl = Downloader(GALLERY_URL, first=1, last=3)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
     for label in ('0002', '0003'):
         mocked_http.add(
@@ -145,7 +145,7 @@ def test_run_with_first_last_range_downloads_subset(mocked_http, tmp_path: Path)
     assert files == ['0002.jpg', '0003.jpg']
 
 
-def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader_in_tmp: Downloader) -> None:
     # All three respond with a content-type ``guess_extension`` cannot map.
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
@@ -159,7 +159,7 @@ def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader
         downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
 
 
-def test_run_cli_uses_tqdm_progress_bar(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_cli_uses_tqdm_progress_bar(mocked_http, downloader_in_tmp: Downloader) -> None:
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
             responses.GET,
@@ -178,7 +178,7 @@ def test_progress_bar_dataclass_shape() -> None:
     assert callable(bar.update)
 
 
-def test_run_honours_preset_cancel_event(mocked_http, downloader_in_tmp: AntenatiDownloader) -> None:
+def test_run_honours_preset_cancel_event(mocked_http, downloader_in_tmp: Downloader) -> None:
     # Register all canvases as 200s; with cancel already set when run()
     # starts, no fetch should be attempted and the total bytes returned
     # must be zero. The mock is created with assert_all_requests_are_fired

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -2,7 +2,7 @@
 
 Exercises both the pure helpers in :mod:`antenati.iiif` /
 :mod:`antenati.http` and the orchestration in
-:class:`antenati.AntenatiDownloader`.
+:class:`antenati.Downloader`.
 """
 
 from __future__ import annotations
@@ -12,14 +12,14 @@ import responses
 from requests import Session
 
 import antenati
-from antenati import AntenatiDownloader
+from antenati import Downloader
 from antenati import http as antenati_http
 from antenati import iiif as antenati_iiif
 from antenati.errors import ManifestError, WafChallengeError
 from tests.conftest import ARCHIVE_ID, GALLERY_URL, MANIFEST_URL
 
 
-def test_archive_id_is_extracted_from_url(downloader: AntenatiDownloader) -> None:
+def test_archive_id_is_extracted_from_url(downloader: Downloader) -> None:
     assert downloader.archive_id == ARCHIVE_ID
 
 
@@ -34,26 +34,26 @@ def test_archive_id_helper_raises_when_url_lacks_two_numbers() -> None:
 
 def test_constructor_raises_when_url_lacks_two_numbers(mocked_http) -> None:
     with pytest.raises(ManifestError, match='Cannot get archive ID'):
-        AntenatiDownloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
+        Downloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
 
 
-def test_manifest_is_loaded_from_gallery_html(downloader: AntenatiDownloader) -> None:
+def test_manifest_is_loaded_from_gallery_html(downloader: Downloader) -> None:
     assert downloader.manifest['@id'] == MANIFEST_URL
     assert len(downloader.manifest['sequences'][0]['canvases']) == 3
 
 
-def test_gallery_url_is_recorded(downloader: AntenatiDownloader) -> None:
+def test_gallery_url_is_recorded(downloader: Downloader) -> None:
     assert downloader.url == GALLERY_URL
 
 
 def test_canvases_are_sliced_by_first_last(mocked_http) -> None:
-    dl = AntenatiDownloader(GALLERY_URL, first=1, last=2)
+    dl = Downloader(GALLERY_URL, first=1, last=2)
     assert dl.gallery_length == 1
     assert dl.canvases[0]['label'] == '0002'
 
 
 def test_first_last_full_range(mocked_http) -> None:
-    dl = AntenatiDownloader(GALLERY_URL, first=0, last=None)
+    dl = Downloader(GALLERY_URL, first=0, last=None)
     assert dl.gallery_length == 3
 
 
@@ -94,7 +94,7 @@ def test_constructor_raises_when_html_lacks_manifest(gallery_html: str) -> None:
             content_type='text/html; charset=utf-8',
         )
         with pytest.raises(ManifestError, match='No IIIF manifest found'):
-            AntenatiDownloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None)
 
 
 def test_constructor_raises_on_invalid_manifest_line() -> None:
@@ -110,7 +110,7 @@ def test_constructor_raises_on_invalid_manifest_line() -> None:
             content_type='text/html; charset=utf-8',
         )
         with pytest.raises(ManifestError, match='Invalid IIIF manifest line'):
-            AntenatiDownloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None)
 
 
 def test_waf_challenge_is_detected() -> None:
@@ -124,7 +124,7 @@ def test_waf_challenge_is_detected() -> None:
             content_type='text/html; charset=utf-8',
         )
         with pytest.raises(WafChallengeError, match='AWS WAF challenge'):
-            AntenatiDownloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None)
 
 
 def test_get_content_type_strips_parameters() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from antenati import AntenatiDownloader
+from antenati import Downloader
 from antenati import iiif as antenati_iiif
 from antenati.errors import ManifestError
 
@@ -25,7 +25,7 @@ def test_get_metadata_value_without_metadata_field_raises() -> None:
 
 
 def test_generate_dirname_combines_metadata_and_archive_id(
-    downloader: AntenatiDownloader,
+    downloader: Downloader,
 ) -> None:
     # slugify lowercases and replaces slashes/spaces with single dashes
     name = str(downloader.dirname)
@@ -35,7 +35,7 @@ def test_generate_dirname_combines_metadata_and_archive_id(
     assert 'stato-civile-italiano' in name
 
 
-def test_print_gallery_info_outputs_metadata(downloader: AntenatiDownloader, capsys: pytest.CaptureFixture[str]) -> None:
+def test_print_gallery_info_outputs_metadata(downloader: Downloader, capsys: pytest.CaptureFixture[str]) -> None:
     downloader.print_gallery_info()
     out = capsys.readouterr().out
     assert 'Contesto archivistico' in out

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -6,12 +6,26 @@ added next to this file. Live-download tests live under tests/integration/
 behind the `integration` marker.
 """
 
+import warnings
+
 import antenati
 
 
 def test_module_imports() -> None:
     assert antenati.__version__
-    assert antenati.AntenatiDownloader is not None
+    assert antenati.Downloader is not None
     assert antenati.ProgressBar is not None
     assert antenati.DEFAULT_SIZE == 0
     assert antenati.DEFAULT_N_THREADS == 2
+
+
+def test_antentati_downloader_alias_emits_deprecation_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        cls = antenati.AntenatiDownloader
+    assert cls is antenati.Downloader
+    assert len(caught) == 1
+    w = caught[0]
+    assert issubclass(w.category, DeprecationWarning)
+    assert 'AntenatiDownloader' in str(w.message)
+    assert 'v7.0' in str(w.message)


### PR DESCRIPTION
This pull request removes the legacy `AntenatiDownloader` alias in favor of using `Downloader` directly, and introduces a deprecation warning for any continued use of `AntenatiDownloader`. All references in the codebase and tests have been updated accordingly to use `Downloader`. This change helps clean up the API and prepares for a future major version bump where the legacy alias will be removed entirely.

Deprecation and API cleanup:

* Removed the `AntenatiDownloader` alias from the `antenati` module and replaced it with a module-level `__getattr__` that emits a `DeprecationWarning` when `AntenatiDownloader` is accessed, indicating it will be removed in v7.0. (`src/antenati/__init__.py`) [[1]](diffhunk://#diff-3f0b6d515ae143195522134494e05791cc65604ebe5c8130c5c3e7c63fcef91aL28-L37) [[2]](diffhunk://#diff-3f0b6d515ae143195522134494e05791cc65604ebe5c8130c5c3e7c63fcef91aR41-R51)
* Updated all internal and test code to use `Downloader` instead of `AntenatiDownloader`, including type annotations, docstrings, and test fixtures. (`tests/conftest.py`, `tests/test_check_dir.py`, `tests/test_download_run.py`, `tests/test_iiif_parsing.py`, `tests/test_metadata.py`, `tests/test_smoke.py`) [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L6-R6) [[2]](diffhunk://#diff-613dece9b2856634f0365b69e6e601063d7ce075cb47ff0a84c775df7dd3e255L1-R25) [[3]](diffhunk://#diff-ee400b2ed3ce61d8662a2ba9e36f9d38df5d87aeb0edcb21e0e27c326802bbdfL1-R1) [[4]](diffhunk://#diff-c826bb1ab0b5737ad54ea810debe36cd2093967885531eef29b63a36cfb220ceL5-R5) [[5]](diffhunk://#diff-f49ce5cf2ce23f6922b7add17ca149482d190f1c2b5892c5d1d55a28497c5556L7-R7) [[6]](diffhunk://#diff-da9ef240243bf38ab4e33d1f8a2a64caee7677dc780e58557f3c676687a4b334R9-R31)

Testing and documentation:

* Added a test to ensure that accessing `AntenatiDownloader` emits the appropriate deprecation warning and still returns `Downloader`. (`tests/test_smoke.py`)
* Updated docstrings and comments throughout the codebase and tests to reference `Downloader` instead of the deprecated alias. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L6-R6) [[2]](diffhunk://#diff-ee400b2ed3ce61d8662a2ba9e36f9d38df5d87aeb0edcb21e0e27c326802bbdfL1-R1) [[3]](diffhunk://#diff-c826bb1ab0b5737ad54ea810debe36cd2093967885531eef29b63a36cfb220ceL5-R5) [[4]](diffhunk://#diff-613dece9b2856634f0365b69e6e601063d7ce075cb47ff0a84c775df7dd3e255L1-R25)

Deprecation warning mechanism:

* Introduced the use of the `warnings` module and a module-level `__getattr__` to provide a smooth transition for users still relying on the old alias, while clearly signaling the upcoming breaking change. (`src/antenati/__init__.py`) [[1]](diffhunk://#diff-3f0b6d515ae143195522134494e05791cc65604ebe5c8130c5c3e7c63fcef91aR5) [[2]](diffhunk://#diff-3f0b6d515ae143195522134494e05791cc65604ebe5c8130c5c3e7c63fcef91aR41-R51)