### PR TITLE
Add Python 3.14 to classifiers and CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Multimedia :: Graphics",
 ]


### PR DESCRIPTION
This pull request adds support for Python 3.14 to the project's CI pipeline and metadata. The main changes ensure that the project is tested and advertised as compatible with Python 3.14.

**CI/CD pipeline updates:**
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL55-R55): Updated the test matrix to include Python 3.14, so CI will now run tests against this version.

**Project metadata:**
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R30): Added Python 3.14 to the `classifiers` list, indicating official support for this version on package indexes.