### PR TITLE
Add dev tooling scaffold (ruff, mypy, pytest, pre-commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ Then, copy the link to the first page, and call the script with that link as arg
     antenati https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x
 
 The results will be placed in a folder named *archivio-di-stato-di-lucca-stato-civile-napoleonico-viareggio-1807-nati-19944549*.
+
+To include the archive and image IDs in the saved file names (e.g. `pag-1+an_ua19944535+w9DWR8x.jpg` instead of `pag-1.jpg`), add the `-d`/`--descriptive-names` flag.
+
+## AWS WAF challenge
+
+Outside Italy, the Portale Antenati gallery pages are often protected by an AWS WAF challenge that this tool cannot solve, and the download fails with an *AWS WAF challenge cannot be bypassed* error (see [#25](https://github.com/gcerretani/antenati/issues/25)). The IIIF manifest and the images themselves are **not** behind the WAF, so you can work around it:
+
+1. open the gallery page in your browser;
+2. copy the **IIIF manifest** link at the bottom of the left side panel (it looks like `https://dam-antenati.cultura.gov.it/antenati/containers/.../manifest`);
+3. pass that URL to the tool (both CLI and GUI) instead of the gallery page URL.

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -41,7 +41,7 @@ def main() -> None:
         epilog=__copyright__,
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument('url', metavar='URL', type=str, help='url of the gallery page')
+    parser.add_argument('url', metavar='URL', type=str, help='url of the gallery page or of its IIIF manifest')
     parser.add_argument(
         '-s',
         '--size',
@@ -70,6 +70,12 @@ def main() -> None:
         default=None,
         help='first image NOT to download',
     )
+    parser.add_argument(
+        '-d',
+        '--descriptive-names',
+        action='store_true',
+        help='include the archive and image IDs in the saved file names',
+    )
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument(
         '--verbose',
@@ -80,7 +86,7 @@ def main() -> None:
     args = parser.parse_args()
 
     _configure_logging(args.verbose)
-    downloader = Downloader(args.url, args.first, args.last)
+    downloader = Downloader(args.url, args.first, args.last, descriptive_names=args.descriptive_names)
     downloader.print_gallery_info()
     downloader.check_dir()
     gallery_size = run_cli(downloader, args.nthreads, args.size)

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -56,32 +56,56 @@ class Downloader:
 
     url: str
     session: Session
-    archive_id: str
+    descriptive_names: bool
     manifest: dict[str, Any]
     canvases: list[dict[str, Any]]
+    archive_id: str
+    ark_id: str
     dirname: Path
     gallery_length: int
 
-    def __init__(self, url: str, first: int, last: int | None):
+    def __init__(self, url: str, first: int, last: int | None, descriptive_names: bool = False):
         self.url = url
         self.session = http.build_session()
-        self.archive_id = iiif.get_archive_id_from_url(url)
-        logger.info('Loading manifest for archive %s', self.archive_id)
+        self.descriptive_names = descriptive_names
+        # A gallery URL embeds the archive ID: extract it up front so a
+        # malformed URL fails before any network round-trip. A manifest
+        # URL does not embed it; in that case it is recovered after the
+        # fetch from the first canvas @id, the only place the manifest
+        # repeats it.
+        archive_id = None if iiif.is_manifest_url(url) else iiif.get_archive_id_from_url(url)
+        logger.info('Loading manifest from %s', url)
         self.manifest = self.__load_manifest()
         self.canvases = iiif.slice_canvases(self.manifest, first, last)
+        self.archive_id = archive_id if archive_id is not None else iiif.get_archive_id_from_canvases(self.canvases)
+        self.ark_id = self.__resolve_ark_id()
         self.dirname = self.__generate_dirname()
         self.gallery_length = len(self.canvases)
         logger.info('Manifest loaded: %d canvases selected', self.gallery_length)
 
     def __load_manifest(self) -> dict[str, Any]:
-        gallery_reply = http.fetch(self.session, self.url)
-        gallery_charset = http.get_content_charset(gallery_reply) or 'utf-8'
-        gallery_html = gallery_reply.content.decode(gallery_charset)
-        manifest_url = iiif.parse_manifest_url_from_html(gallery_html, self.url)
+        if iiif.is_manifest_url(self.url):
+            # The manifest endpoint is not behind the AWS WAF, so a user
+            # who gets a challenge on the gallery page can copy the "IIIF
+            # manifest" link from it and pass that URL directly (issue #25).
+            manifest_url = self.url
+        else:
+            gallery_reply = http.fetch(self.session, self.url)
+            gallery_charset = http.get_content_charset(gallery_reply) or 'utf-8'
+            gallery_html = gallery_reply.content.decode(gallery_charset)
+            manifest_url = iiif.parse_manifest_url_from_html(gallery_html, self.url)
         logger.debug('Manifest URL: %s', manifest_url)
         manifest_reply = http.fetch(self.session, manifest_url)
         manifest_charset = http.get_content_charset(manifest_reply) or 'utf-8'
         return loads(manifest_reply.content.decode(manifest_charset))
+
+    def __resolve_ark_id(self) -> str:
+        first_canvas_url = str(self.canvases[0].get('@id', ''))
+        for candidate in (self.url, first_canvas_url):
+            ark = iiif.get_ark_id_from_url(candidate)
+            if ark:
+                return ark
+        return self.archive_id
 
     def __generate_dirname(self) -> Path:
         context = iiif.get_metadata_value(self.manifest, iiif.META_CONTEXT)
@@ -116,13 +140,16 @@ class Downloader:
         label = slugify(canvas['label'])
         try:
             image_url = iiif.image_url_for_canvas(canvas)
+            stem = label
+            if self.descriptive_names:
+                stem = f'{label}+{self.ark_id}+{iiif.get_image_id_from_url(image_url)}'
             url = iiif.manipulate_image_url(image_url, size)
             http_reply = http.fetch(self.session, url)
             content_type = http.get_content_type(http_reply)
             extension = guess_extension(content_type)
             if not extension:
                 raise RuntimeError(f'{url}: Unable to guess extension "{content_type}"')
-            filename = self.dirname / f'{label}{extension}'
+            filename = self.dirname / f'{stem}{extension}'
             with open(filename, 'wb') as img_file:
                 img_file.write(http_reply.content)
             return len(http_reply.content)

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -70,7 +70,7 @@ class App:
         entry_frame = ttk.Frame(self._root)
         entry_frame.pack(side=tk.TOP, fill=tk.X)
 
-        tk.Label(entry_frame, text='Archive URL').grid(row=0, column=0, padx=10, pady=5, sticky=tk.W)
+        tk.Label(entry_frame, text='Archive or manifest URL').grid(row=0, column=0, padx=10, pady=5, sticky=tk.W)
         ttk.Entry(entry_frame, textvariable=self._url, width=100).grid(row=0, column=1, padx=10, pady=5, columnspan=3, sticky=tk.EW)
 
         options = ttk.LabelFrame(entry_frame, text='Options')

--- a/src/antenati/http.py
+++ b/src/antenati/http.py
@@ -92,16 +92,21 @@ def fetch(session: Session, url: str) -> Response:
         exhausted for retryable statuses).
     WafChallengeError
         If the server returned an AWS WAF challenge (HTTP 202 with the
-        ``x-amzn-waf-action: challenge`` header). There is currently no
-        bypass; surfacing this as a distinct error helps callers diagnose
-        the problem without parsing HTML.
+        ``x-amzn-waf-action: challenge`` header). Only the gallery pages
+        are behind the WAF: the error message points the user at the
+        manifest-URL workaround.
     """
     logger.debug('GET %s', url)
     reply = session.get(url)
     reply.raise_for_status()
     if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
         logger.warning('WAF challenge received from %s', reply.url)
-        raise WafChallengeError(f'{reply.url}: AWS WAF challenge cannot be bypassed. See https://github.com/gcerretani/antenati/issues/25 for details.')
+        raise WafChallengeError(
+            f'{reply.url}: AWS WAF challenge cannot be bypassed. '
+            'Workaround: open the gallery page in a browser, copy the "IIIF manifest" link '
+            'at the bottom of the left panel and pass that URL to this tool instead. '
+            'See https://github.com/gcerretani/antenati/issues/25 for details.'
+        )
     return reply
 
 

--- a/src/antenati/iiif.py
+++ b/src/antenati/iiif.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from re import findall, search
 from typing import Any
+from urllib.parse import urlsplit
 
 from antenati.errors import ManifestError
 
@@ -37,6 +38,18 @@ META_TITLE: str = 'Titolo'
 META_TYPOLOGY: str = 'Tipologia'
 
 
+def is_manifest_url(url: str) -> bool:
+    """Return True when ``url`` points directly to a IIIF manifest.
+
+    Every Portale Antenati gallery page links its manifest ("IIIF
+    manifest", at the bottom of the left panel). Unlike the gallery page
+    itself, the manifest endpoint is not protected by the AWS WAF, so
+    accepting it as input gives users a challenge-free entry point
+    (https://github.com/gcerretani/antenati/issues/25).
+    """
+    return urlsplit(url).path.rstrip('/').endswith('/manifest')
+
+
 def get_archive_id_from_url(url: str) -> str:
     """Return the archive ID embedded in a Portale Antenati gallery URL.
 
@@ -51,6 +64,46 @@ def get_archive_id_from_url(url: str) -> str:
     if len(numbers) < 2:
         raise ManifestError(f'Cannot get archive ID from {url}')
     return numbers[1]
+
+
+def get_archive_id_from_canvases(canvases: list[dict[str, Any]]) -> str:
+    """Return the archive ID from the first canvas ``@id`` URL.
+
+    A manifest URL does not embed the archive ID, but every canvas
+    ``@id`` does; this is the fallback used when the user provides a
+    manifest URL directly instead of a gallery URL.
+    """
+    try:
+        canonical_url = canvases[0]['@id']
+    except (KeyError, IndexError, TypeError) as exc:
+        raise ManifestError("Canvas has no '@id' field") from exc
+    return get_archive_id_from_url(canonical_url)
+
+
+def get_ark_id_from_url(url: str) -> str | None:
+    """Return the ``an_...`` ark token embedded in a URL, if any.
+
+    Example: ``https://antenati.cultura.gov.it/ark:/12657/an_ua2978553/5gGAbBp``
+    yields ``an_ua2978553``.
+    """
+    match = search(r'an_\w+', url)
+    return match.group(0) if match else None
+
+
+def get_image_id_from_url(url: str) -> str:
+    """Return the IIIF image identifier from an image URL.
+
+    IIIF Image API URLs have the shape
+    ``{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}``,
+    so the identifier is always the fifth path segment from the end::
+
+        https://iiif-antenati.cultura.gov.it/iiif/2/5gGAbBp/full/full/0/default.jpg
+                                                    ^^^^^^^
+    """
+    parts = urlsplit(url).path.split('/')
+    if len(parts) < 5:
+        raise ManifestError(f'Cannot get image ID from {url}')
+    return parts[-5]
 
 
 def parse_manifest_url_from_html(html: str, source_url: str) -> str:

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -16,7 +16,7 @@ import responses
 import antenati
 from antenati import Downloader, ProgressBar
 from antenati import cli as antenati_cli
-from tests.conftest import GALLERY_URL, TINY_JPEG
+from tests.conftest import GALLERY_URL, MANIFEST_URL, TINY_JPEG
 
 
 def _null_progress() -> ProgressBar:
@@ -195,3 +195,40 @@ def test_run_honours_preset_cancel_event(mocked_http, downloader_in_tmp: Downloa
     cancel.set()
     total = downloader_in_tmp.run(n_workers=1, size=0, progress=_null_progress(), cancel=cancel)
     assert total == 0
+
+
+def test_run_descriptive_names_embed_ark_and_image_ids(mocked_http, tmp_path: Path) -> None:
+    dl = Downloader(GALLERY_URL, first=0, last=None, descriptive_names=True)
+    dl.check_dir(parentdir=str(tmp_path), interactive=False)
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    dl.run(n_workers=2, size=0, progress=_null_progress())
+    files = sorted(p.name for p in dl.dirname.iterdir())
+    assert files == [
+        '0001+an_ua19944535+img1.jpg',
+        '0002+an_ua19944535+img2.jpg',
+        '0003+an_ua19944535+img3.jpg',
+    ]
+
+
+def test_run_from_manifest_url_downloads_all_images(mocked_http, tmp_path: Path) -> None:
+    dl = Downloader(MANIFEST_URL, first=0, last=None)
+    dl.check_dir(parentdir=str(tmp_path), interactive=False)
+    for label in ('0001', '0002', '0003'):
+        mocked_http.add(
+            responses.GET,
+            _image_url(label, 0),
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    total = dl.run(n_workers=2, size=0, progress=_null_progress())
+    assert total == 3 * len(TINY_JPEG)
+    files = sorted(p.name for p in dl.dirname.iterdir())
+    assert files == ['0001.jpg', '0002.jpg', '0003.jpg']

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -161,3 +161,49 @@ def test_default_thread_count_constant() -> None:
 
 def test_default_size_constant() -> None:
     assert antenati.DEFAULT_SIZE == 0
+
+
+def test_is_manifest_url_detects_manifest_paths() -> None:
+    assert antenati_iiif.is_manifest_url('https://dam-antenati.cultura.gov.it/antenati/containers/0ADVMr3/manifest')
+    assert antenati_iiif.is_manifest_url(MANIFEST_URL)
+    assert antenati_iiif.is_manifest_url(MANIFEST_URL + '/')
+    assert not antenati_iiif.is_manifest_url(GALLERY_URL)
+
+
+def test_archive_id_is_recovered_from_canvases(manifest_dict: dict) -> None:
+    canvases = manifest_dict['sequences'][0]['canvases']
+    assert antenati_iiif.get_archive_id_from_canvases(canvases) == ARCHIVE_ID
+
+
+def test_archive_id_from_canvases_raises_on_missing_id() -> None:
+    with pytest.raises(ManifestError, match="Canvas has no '@id'"):
+        antenati_iiif.get_archive_id_from_canvases([{'label': '0001'}])
+
+
+def test_ark_id_is_extracted_from_gallery_url() -> None:
+    assert antenati_iiif.get_ark_id_from_url(GALLERY_URL) == f'an_ua{ARCHIVE_ID}'
+
+
+def test_ark_id_is_none_when_absent() -> None:
+    assert antenati_iiif.get_ark_id_from_url(MANIFEST_URL) is None
+
+
+def test_image_id_is_extracted_from_iiif_image_url() -> None:
+    url = 'https://iiif-antenati.cultura.gov.it/iiif/2/5gGAbBp/full/full/0/default.jpg'
+    assert antenati_iiif.get_image_id_from_url(url) == '5gGAbBp'
+
+
+def test_image_id_raises_on_short_path() -> None:
+    with pytest.raises(ManifestError, match='Cannot get image ID'):
+        antenati_iiif.get_image_id_from_url('https://example.org/too/short')
+
+
+def test_downloader_accepts_manifest_url_directly(mocked_http) -> None:
+    # The gallery page is never fetched: only the manifest URL is hit.
+    # This is the workaround for galleries behind the AWS WAF challenge
+    # (https://github.com/gcerretani/antenati/issues/25).
+    dl = Downloader(MANIFEST_URL, first=0, last=None)
+    assert dl.archive_id == ARCHIVE_ID
+    assert dl.gallery_length == 3
+    requested = [call.request.url for call in mocked_http.calls]
+    assert requested == [MANIFEST_URL]


### PR DESCRIPTION
First step of the refactor planned for v6: introduce the development
toolchain without touching production code. Adds:

- pyproject.toml with ruff/mypy/pytest config tuned for the current
  single-file layout. Strict rules are gated per-file so the existing
  antenati.py/antenati_gui.py keep passing; they will be enabled module
  by module as the refactor extracts pure modules under src/antenati/.
- .pre-commit-config.yaml wiring ruff, ruff-format and mypy.
- tests/ directory with an initial smoke test. Live-download tests will
  live under tests/integration/ behind the `integration` pytest marker.
- A new `lint` job in pythonapp.yml running ruff, ruff-format, mypy and
  the offline pytest suite on every push and PR. The existing live
  download job still runs, gated on `lint` succeeding first.