### PR TITLE
Drop macOS 13 Intel support and update CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: ['ubuntu-22.04', 'macos-14', 'macos-13', 'windows-2022']
+        runs-on: ['ubuntu-22.04', 'macos-14', 'windows-2022']
     runs-on: ${{ matrix.runs-on }}
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic exponential backoff retry policy for transient 5xx and rate-limit (429) responses
 
 ### Changed
+- Dropped Intel macOS (macOS 13) binary artifacts: GitHub Actions no longer provides Intel macOS runners; only Apple Silicon (macOS 14, arm64) is now built
 - Refactored monolithic `antenati.py` into a modular package structure under `src/antenati/`:
   - `downloader.py`: core `Downloader` class with thread-pool orchestration
   - `iiif.py`: pure IIIF manifest parsing helpers (no I/O, offline-testable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Pyinstaller artifacts now built with Python 3.12
 - Support for multiple platforms:
-  - Ubuntu 22.04 (arm64)
+  - Ubuntu 22.04 (x86_64)
   - macOS 13 (Intel)
   - macOS 14 (arm64)
   - Windows 2022


### PR DESCRIPTION
This pull request updates the build configuration and documentation to reflect the discontinuation of Intel macOS (macOS 13) support. The most important changes are:

Build and platform support updates:

* The GitHub Actions workflow in `.github/workflows/release.yml` no longer builds or releases Intel macOS (macOS 13) artifacts, as GitHub Actions has dropped support for Intel macOS runners. Only Apple Silicon (macOS 14, arm64), Ubuntu 22.04, and Windows 2022 are now built.
* The `CHANGELOG.md` has been updated to note the removal of Intel macOS (macOS 13) binary artifacts and clarify that only Apple Silicon (macOS 14, arm64) is now built.

Documentation corrections:

* The supported Ubuntu platform in `CHANGELOG.md` has been corrected from "Ubuntu 22.04 (arm64)" to "Ubuntu 22.04 (x86_64)" to accurately reflect the build targets.