### PR TITLE
Let the daily live-download canary report failures

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -14,10 +14,17 @@ jobs:
   live:
     name: Live download against Portale Antenati
     runs-on: ubuntu-24.04
-    # We do NOT block PRs on this job: the Portale is intermittently slow
-    # or under WAF challenge, which would cause unrelated PRs to fail.
-    # CI failures show up as a red badge on the Actions tab instead.
-    continue-on-error: true
+    # This job does not gate PRs: the workflow has no push/pull_request
+    # trigger, so a red run here never blocks unrelated work. A failure is
+    # therefore allowed to surface normally, as a failed run with the usual
+    # GitHub notification.
+    #
+    # Expect occasional false positives: the Portale is intermittently slow,
+    # under WAF challenge, or returning 5xx from the IIIF backend. The
+    # urllib3 Retry policy in antenati.http already absorbs the short-lived
+    # ones, so a failure here generally means the SAN was actually down.
+    # Re-run the job before investigating a single isolated failure; a
+    # failure repeating across days is the signal worth chasing.
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `live.yml` carried `continue-on-error: true`, which masks failures at the workflow-run level: a job that fails still leaves the run's `conclusion` as `success`. Run [31242900582](https://github.com/gcerretani/antenati/actions/runs/31242900582) is a concrete example — two IIIF images returned HTTP 500 and the job concluded `failure`, yet the run shows green in the Actions list, so no notification fires and the badge stays green.
- The stated rationale in the removed comment no longer applies: the workflow only triggers on `schedule` and `workflow_dispatch`, so it can't block PRs regardless of this flag. The comment also claimed failures would show as a red badge, which is exactly what `continue-on-error` prevented.
- Replaced the comment with one documenting the expected false-positive rate instead: the `Retry` policy in `antenati.http` already absorbs transient 5xx/rate-limit responses, so a failure that reaches the run conclusion is generally real SAN downtime rather than recoverable flakiness.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/live.yml'))"` — YAML parses, `continue-on-error` no longer present in the `live` job
- [ ] Confirm the next scheduled `live.yml` run (05:23 UTC) reports its true conclusion and, if it fails, triggers the standard GitHub failure notification


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1HA3UW3cwEBY65j2kVGvo)_