### PR TITLE
v7.0: verified, resumable download architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: ruff check .
 
     - name: Ruff format check
-      run: ruff format --check .
+      run: ruff format --diff .
 
     - name: Mypy
       run: mypy src/antenati

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: ruff check .
 
     - name: Ruff format check
-      run: ruff format --diff .
+      run: ruff format --check .
 
     - name: Mypy
       run: mypy src/antenati

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0] - Unreleased
+
+### Added
+- Verified resume support that reuses existing files only when provenance, requested resolution, byte size and SHA-256 still match (#59)
+- Structured `DownloadReport` shared by CLI and GUI, with expected, attempted, completed, skipped, failed and cancelled state (#60)
+- Persistent `.antenati-manifest.json` and `.antenati-index.json` provenance with per-image canvas/source mapping, requested size, byte size, SHA-256 and timestamp (#61)
+- Explicit output selection and `error`, `overwrite`, `skip` and `resume` existing-output policies in CLI and GUI (#62)
+- CLI `--dry-run` preview of the exact planned pages, filenames and image URLs without image writes (#63)
+- Shared CLI/GUI configuration model, including worker-count and descriptive-filename controls in the GUI (#64)
+- Resource ceilings for metadata, image size, canvas count, total bytes and bounded in-flight work (#50)
+
+### Changed
+- Split downloader construction, source loading, planning and execution into explicit phases; constructing a `Downloader` no longer performs network I/O (#67)
+- Numeric page labels are zero-padded from the complete gallery size so lexicographic filename order matches page order and remains stable across subsets (#73)
+- Image bodies are streamed instead of buffered in memory, and queued work is bounded relative to worker count (#50)
+- CLI, GUI and programmatic execution now share preflight validation for page ranges, image size and worker count (#52)
+- README now describes the actual single-gallery/register scope, Antenati-specific IIIF support, integrity guarantees and live-site limitations (#68)
+
+### Fixed
+- Reject unsupported media types, HTML/text responses, corrupt image data and MIME/signature mismatches before a final image file is committed (#47)
+- Missing or invalid response metadata and malformed selections now fail with controlled domain errors instead of late technical exceptions (#52)
+- Existing files are never silently treated as valid by resume/skip semantics without matching provenance and integrity checks (#59, #62)
+
+### Testing
+- Expanded offline regression coverage for cancellation side effects, filename collisions and padding, atomic/integrity guarantees, report/file consistency, provenance, verified resume, output policies, resource limits and shared configuration (#66)
 
 ## [6.2] - 2026-09-06
 
@@ -59,7 +84,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Graceful handling of server denials (403 or WAF challenge)
-
 
 ## [4.0] - 2025-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified resume support that reuses existing files only when provenance, requested resolution, byte size and SHA-256 still match (#59)
 - Structured `DownloadReport` shared by CLI and GUI, with expected, attempted, completed, skipped, failed and cancelled state (#60)
 - Persistent `.antenati-manifest.json` and `.antenati-index.json` provenance with per-image canvas/source mapping, requested size, byte size, SHA-256 and timestamp (#61)
-- Explicit output selection and `error`, `overwrite`, `skip` and `resume` existing-output policies in CLI and GUI (#62)
+- Explicit output selection and `ask`, `error`, `overwrite`, `skip` and `resume` existing-output policies in CLI and GUI; `ask` is the shared interactive default and recommends verified resume (#62)
 - CLI `--dry-run` preview of the exact planned pages, filenames and image URLs without image writes (#63)
 - Shared CLI/GUI configuration model, including worker-count and descriptive-filename controls in the GUI (#64)
 - Resource ceilings for metadata, image size, canvas count, total bytes and bounded in-flight work (#50)
@@ -21,12 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Numeric page labels are zero-padded from the complete gallery size so lexicographic filename order matches page order and remains stable across subsets (#73)
 - Image bodies are streamed instead of buffered in memory, and queued work is bounded relative to worker count (#50)
 - CLI, GUI and programmatic execution now share preflight validation for page ranges, image size and worker count (#52)
-- README now describes the actual single-gallery/register scope, Antenati-specific IIIF support, integrity guarantees and live-site limitations (#68)
+- README now documents standalone GitHub Release executables as the recommended path for non-Python users, alongside PyPI and source/development installation, and describes the actual single-gallery/register scope and integrity guarantees (#68)
 
 ### Fixed
 - Reject unsupported media types, HTML/text responses, corrupt image data and MIME/signature mismatches before a final image file is committed (#47)
 - Missing or invalid response metadata and malformed selections now fail with controlled domain errors instead of late technical exceptions (#52)
 - Existing files are never silently treated as valid by resume/skip semantics without matching provenance and integrity checks (#59, #62)
+- Restored interactive handling of non-empty output directories through the explicit `ask` policy instead of failing by default (#62)
 
 ### Testing
 - Expanded offline regression coverage for cancellation side effects, filename collisions and padding, atomic/integrity guarantees, report/file consistency, provenance, verified resume, output policies, resource limits and shared configuration (#66)
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [6.2] - 2026-09-06
 
 ### Fixed
-- Prevent silent overwrites when multiple canvases normalize to the same default filename; later collisions now receive deterministic suffixes
+- Prevent silent overwrites when multiple canvases normalize to same default filename; later collisions now receive deterministic suffixes
 - Add bounded HTTP connect/read timeouts and ensure a cancellation already requested before `run()` performs no image requests
 - Write downloads through temporary files and atomically replace the destination only after a complete write, preserving existing good files on write failures and avoiding symlink-following writes
 - Fix a Tk GUI race where the terminal `Done`/`Failed`/`Cancelled` event could remain unprocessed after the worker exited

--- a/README.md
+++ b/README.md
@@ -5,117 +5,149 @@
 [![License: GPL-3.0-or-later](https://img.shields.io/pypi/l/antenati)](https://github.com/gcerretani/antenati/blob/master/LICENSE)
 [![CI](https://github.com/gcerretani/antenati/actions/workflows/ci.yml/badge.svg)](https://github.com/gcerretani/antenati/actions/workflows/ci.yml)
 
-**The only tool that lets you download full-resolution images from the
-*[Portale Antenati](https://antenati.cultura.gov.it/)*, the genealogy digital
-archive of the Italian *Ministero della Cultura*.**
+`antenati` downloads the digitised pages of a **single gallery/register** from the Italian [Portale Antenati](https://antenati.cultura.gov.it/), using the IIIF manifest exposed by the portal.
 
-The Portale Antenati hosts millions of digitised civil and parish records, but
-its web viewer only lets you look at one page at a time — and the servers slow
-to a crawl in the evening. `antenati` reads the standard
-[IIIF](https://iiif.io/) manifest behind each gallery and downloads **every
-image of an entire archive in one shot, at the highest resolution available**,
-with no clicking and no waiting. Launch it, grab a coffee, and come back to a
-folder full of records ready for your family tree.
+One invocation resolves one gallery or direct Antenati manifest, builds a deterministic download plan and writes the selected pages to disk. It does **not** recursively mirror an Archivio di Stato, a municipality, or search results from the portal.
 
 ## Highlights
 
-- 🖼️ **Full-resolution downloads** — the only tool that still retrieves images at maximum size from the portal.
-- 📚 **Whole archives at once** — point it at a gallery and it fetches every page automatically.
-- ⚡ **Fast & parallel** — multi-threaded downloads with automatic retry/backoff on transient errors.
-- 🖥️ **CLI *and* GUI** — a scriptable command line and a friendly desktop window, from the same package.
-- 🧩 **IIIF-native** — works directly with the portal's IIIF manifests, so it keeps working when the web viewer changes.
-- 🌍 **Cross-platform** — Windows, macOS and Linux; install with `pip` or grab a standalone executable.
+- **Full-resolution or resized images** — request the original IIIF image size or a bounded size.
+- **Deterministic filenames** — numeric page labels are zero-padded from the complete gallery size, and collisions are resolved deterministically.
+- **Verified image writes** — supported image MIME types and file signatures are checked before the temporary file is atomically promoted to its final filename.
+- **Verified resume** — existing files are reused only when provenance, requested resolution, byte size and SHA-256 still match.
+- **Persistent provenance** — each completed run stores the source manifest plus a per-image JSON index with canvas/source mapping, size and hash.
+- **Bounded execution** — image bodies are streamed, in-flight work is bounded and explicit resource ceilings protect against anomalous sources.
+- **Preview mode** — inspect the exact pages, source URLs and output filenames before image files are written.
+- **CLI and GUI** — both use the same core configuration and validation rules.
+- **Cross-platform** — Windows, macOS and Linux; install with `pip` or use a release executable when available.
 
 ## Installation
 
-The recommended way to install `antenati` is from [PyPI](https://pypi.org/project/antenati/):
+Install from PyPI:
 
-    pip install antenati
+```text
+pip install antenati
+```
 
-This requires **Python 3.10 or newer** and gives you two commands on your `PATH`:
+Python **3.10 or newer** is required. The package installs:
 
-- `antenati` — the command-line downloader
-- `antenati-gui` — the graphical interface
+- `antenati` — command-line interface
+- `antenati-gui` — Tk desktop interface
 
-> On Windows the Python build from the Microsoft Store works fine; on Linux use
-> your distribution's package manager to get Python first.
+Standalone GUI executables for supported platforms are attached to GitHub releases when produced by the release workflow.
 
-### Standalone executables (no Python needed)
+## Supported inputs
 
-If you'd rather not install Python and `pip` at all, prebuilt standalone
-executables of the **GUI** for Windows, macOS and Linux are attached to every
-release. Just download the one for your system from the
-[latest release artifacts](https://github.com/gcerretani/antenati/releases/latest)
-and run it — no installation required.
+The supported source is the **Portale Antenati** and the IIIF structures currently emitted by it. You can pass either:
 
-## Usage
+1. an Antenati gallery URL, for example:
 
-### Command line
+   ```text
+   https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x
+   ```
 
-Pass the URL of a gallery page (or of its IIIF manifest) to the `antenati` command:
+2. the direct IIIF manifest URL exposed by that gallery, for example a URL under `dam-antenati.cultura.gov.it/.../manifest`.
 
-    antenati <URL of the album>
+`antenati` is IIIF-based internally, but it is **not currently a generic IIIF downloader**. Broader Presentation/Image API variants may be unsupported even when they are valid IIIF.
 
-The images are saved to a new folder named after the archive, in the form
-*ARCHIVE-PLACE-YEAR-TYPE-ID*.
+## Command line
 
-**Example** — to download the people born in Viareggio in 1807, find the
-gallery page on the portal:
+Basic use:
 
-[https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x](https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x)
+```text
+antenati https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x
+```
 
-then copy the link to the first page and pass it to the tool:
+By default the output directory is derived from the register metadata. Use `--output` to select an exact destination path.
 
-    antenati https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x
-
-The results land in a folder named
-*archivio-di-stato-di-lucca-stato-civile-napoleonico-viareggio-1807-nati-19944549*.
-
-If you didn't install the package, you can still run it as a module:
-
-    python3 -m antenati <URL of the album>
-
-#### Options
+### Core options
 
 | Option | Description |
 |---|---|
-| `-s`, `--size N` | Image size in pixels (`0` = full size, the default). |
-| `-n`, `--nthreads N` | Maximum number of download threads. |
-| `-f`, `--first N` | Index of the first image to download. |
-| `-l`, `--last N` | Index of the first image *not* to download. |
-| `-d`, `--descriptive-names` | Include the archive and image IDs in the file names (e.g. `pag-1+an_ua19944535+w9DWR8x.jpg`). |
-| `--verbose` | Increase log verbosity (`--verbose` → INFO, `--verbose --verbose` → DEBUG). |
+| `-s`, `--size N` | Maximum image size in pixels; `0` requests full resolution. |
+| `-n`, `--nthreads N` | Maximum number of image workers. |
+| `-f`, `--first N` | Zero-based index of the first page to include. |
+| `-l`, `--last N` | Zero-based exclusive end index. |
+| `-d`, `--descriptive-names` | Include archive/image identifiers in filenames. |
+| `-o`, `--output PATH` | Exact output directory. |
+| `--existing {error,overwrite,skip,resume}` | Policy when the output already exists. Default: `error`. |
+| `--dry-run` | Resolve the source and print the planned pages/filenames without downloading image bodies or creating the output directory. |
+| `--verbose` | Increase logging verbosity; repeat for DEBUG. |
 | `-v`, `--version` | Print the version and exit. |
 
-Run `antenati -h` for the full, up-to-date list.
+Run `antenati -h` for the authoritative option list.
 
-### Graphical interface
+### Existing-output policies
 
-Launch the GUI with the `antenati-gui` command (or the standalone executable
-described above):
+- `error` — conservative default; refuse an existing output directory.
+- `overwrite` — allow the run to replace planned destination files through atomic writes.
+- `resume` — verify indexed existing files and redownload only missing, stale, mismatched or corrupt pages.
+- `skip` — reuse only files that can be verified from the provenance index; ambiguous unverified files are never silently accepted.
+
+The same source canvas receives the same planned filename regardless of the selected subset, worker count or completion order. For example, a 150-page gallery uses names such as `pag-001.jpg`; downloading only pages 7–12 still produces the corresponding zero-padded names from the complete gallery.
+
+## Provenance and integrity
+
+A completed output directory contains the downloaded images plus:
+
+- `.antenati-manifest.json` — the source IIIF manifest captured for the run;
+- `.antenati-index.json` — per-image provenance including source/canvas URL, label, filename, requested size, byte size, SHA-256 and download timestamp.
+
+An image is counted as completed only after its response is streamed to a temporary file, the supported image format/signature is validated, the file is flushed, and the temporary path is atomically replaced into its final destination. `DownloadReport` separately tracks expected, attempted, completed, skipped, failed and cancelled work.
+
+These checks improve local integrity; they do not cryptographically authenticate data supplied by the remote archive itself.
+
+## CLI / GUI capability parity
+
+| Capability | CLI | GUI |
+|---|:---:|:---:|
+| Gallery or direct manifest input | yes | yes |
+| Page range | yes | yes |
+| Image size | yes | yes |
+| Worker count | yes | yes |
+| Descriptive filenames | yes | yes |
+| Exact output directory | yes | yes |
+| Existing-output policy | yes | yes |
+| Verified resume | yes | yes |
+| Shared validation/reporting | yes | yes |
+| Dry-run preview | yes | not yet |
+
+Dry-run is currently a CLI review surface; the underlying download plan is shared and can support a future GUI preview without changing execution semantics.
+
+## Graphical interface
+
+Launch:
+
+```text
+antenati-gui
+```
 
 ![GUI Screenshot](https://raw.githubusercontent.com/gcerretani/antenati/master/docs/gui_screenshot.png)
 
-1. Paste the link to the first page of the archive into the **Archive URL** field
-   (e.g. `https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x`).
-2. Choose a destination folder.
-3. The results are saved into a new subfolder named after the archive, such as
-   *archivio-di-stato-di-lucca-stato-civile-napoleonico-viareggio-1807-nati-19944549*.
+Paste a gallery/manifest URL, choose the **exact destination directory**, then select the page range, image size, thread count, descriptive-name option and existing-output policy. The GUI runs the same downloader configuration, validation and result model as the CLI.
 
-## AWS WAF challenge
+## AWS WAF and live-site limitations
 
-Outside Italy, the Portale Antenati gallery pages are often protected by an AWS
-WAF challenge that this tool cannot solve, and the download fails with an *AWS
-WAF challenge cannot be bypassed* error (see
-[#25](https://github.com/gcerretani/antenati/issues/25)). The IIIF manifest and
-the images themselves are **not** behind the WAF, so you can work around it:
+The public gallery HTML can be blocked for automated clients by the portal's AWS WAF. This can happen even while the direct manifest and IIIF image backends remain reachable.
 
-1. open the gallery page in your browser;
-2. copy the **IIIF manifest** link at the bottom of the left side panel (it
-   looks like `https://dam-antenati.cultura.gov.it/antenati/containers/.../manifest`);
-3. pass that URL to the tool (both CLI and GUI) instead of the gallery page URL.
+If a gallery URL fails with an AWS WAF challenge or HTTP 403:
+
+1. open the gallery in a browser;
+2. copy its **IIIF manifest** link from the portal interface;
+3. pass that manifest URL directly to `antenati` or the GUI.
+
+The repository's scheduled live checks intentionally test gallery HTML, direct manifest access and image download as separate canaries so a frontend/WAF failure does not hide backend status.
+
+The Portale Antenati is a third-party service and may change availability, HTML, metadata or IIIF structures without notice. The normal offline test suite verifies the structures supported by this project; it cannot guarantee future portal compatibility.
+
+## Cancellation and resource limits
+
+Cancellation prevents queued work from being started where possible. Requests already active are bounded by HTTP connect/read timeouts rather than being forcibly terminated at an arbitrary byte boundary.
+
+The downloader also applies ceilings to metadata size, image size, canvas count, total downloaded bytes and in-flight work. These are safety limits, not claims about maximum IIIF sizes in general.
 
 ## License
 
 Released under the [GNU General Public License v3 or later](https://www.gnu.org/licenses/gpl-3.0.html).
-See the [changelog](https://github.com/gcerretani/antenati/blob/master/CHANGELOG.md) for release history.
+
+See the [changelog](https://github.com/gcerretani/antenati/blob/master/CHANGELOG.md) for release history and the [issue tracker](https://github.com/gcerretani/antenati/issues) for known limitations and planned work.

--- a/README.md
+++ b/README.md
@@ -19,22 +19,62 @@ One invocation resolves one gallery or direct Antenati manifest, builds a determ
 - **Bounded execution** — image bodies are streamed, in-flight work is bounded and explicit resource ceilings protect against anomalous sources.
 - **Preview mode** — inspect the exact pages, source URLs and output filenames before image files are written.
 - **CLI and GUI** — both use the same core configuration and validation rules.
-- **Cross-platform** — Windows, macOS and Linux; install with `pip` or use a release executable when available.
+- **Cross-platform** — Windows, macOS and Linux, with standalone GUI executables for users who do not want to install Python.
 
-## Installation
+## Installation and ways to use antenati
 
-Install from PyPI:
+There are several supported ways to run the program. **If you do not use Python, the standalone GUI from GitHub Releases is the simplest option.**
+
+### 1. Standalone graphical application — recommended for most users
+
+Open the project's [GitHub Releases](https://github.com/gcerretani/antenati/releases), choose the latest release and download the archive for your operating system from **Assets**:
+
+- **Windows** — `antenati_gui_windows.exe.zip`; extract the ZIP and run `antenati_gui.exe`.
+- **macOS Apple Silicon** — `antenati_gui_macos-14.zip`; extract it and run `antenati_gui`.
+- **Ubuntu/Linux x86_64** — `antenati_gui_ubuntu-22.04.zip`; extract it and run `antenati_gui`.
+
+These are standalone applications built by the release workflow: **Python and `pip` are not required**. On macOS/Linux you may need to allow execution according to your operating system's security settings.
+
+The standalone application provides the graphical interface described below. Paste the gallery URL, choose an output directory and start the download.
+
+### 2. Install from PyPI — recommended for Python/command-line users
+
+Python **3.10 or newer** is required:
 
 ```text
 pip install antenati
 ```
 
-Python **3.10 or newer** is required. The package installs:
+This installs both:
 
-- `antenati` — command-line interface
-- `antenati-gui` — Tk desktop interface
+- `antenati` — command-line interface;
+- `antenati-gui` — Tk desktop interface.
 
-Standalone GUI executables for supported platforms are attached to GitHub releases when produced by the release workflow.
+Examples:
+
+```text
+antenati https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x
+antenati-gui
+```
+
+To upgrade an existing PyPI installation:
+
+```text
+pip install --upgrade antenati
+```
+
+### 3. Run/install from the source repository — for developers
+
+Clone the repository and install it in a virtual environment. For an editable development installation:
+
+```text
+git clone https://github.com/gcerretani/antenati.git
+cd antenati
+python -m venv .venv
+pip install -e ".[dev]"
+```
+
+Activate the virtual environment using the command appropriate for your operating system, then run `antenati` or `antenati-gui`. This method is intended for development and testing; normal users should prefer a release executable or PyPI.
 
 ## Supported inputs
 
@@ -70,7 +110,7 @@ By default the output directory is derived from the register metadata. Use `--ou
 | `-l`, `--last N` | Zero-based exclusive end index. |
 | `-d`, `--descriptive-names` | Include archive/image identifiers in filenames. |
 | `-o`, `--output PATH` | Exact output directory. |
-| `--existing {error,overwrite,skip,resume}` | Policy when the output already exists. Default: `error`. |
+| `--existing {ask,error,overwrite,skip,resume}` | Policy when the output already exists. Default: `ask`. |
 | `--dry-run` | Resolve the source and print the planned pages/filenames without downloading image bodies or creating the output directory. |
 | `--verbose` | Increase logging verbosity; repeat for DEBUG. |
 | `-v`, `--version` | Print the version and exit. |
@@ -79,10 +119,13 @@ Run `antenati -h` for the authoritative option list.
 
 ### Existing-output policies
 
-- `error` — conservative default; refuse an existing output directory.
-- `overwrite` — allow the run to replace planned destination files through atomic writes.
+- `ask` — default interactive behavior. If the destination is non-empty, CLI/GUI ask what to do; verified `resume` is the recommended/default choice.
+- `error` — refuse a non-empty existing output directory without asking.
+- `overwrite` — download again and replace planned destination files through atomic writes.
 - `resume` — verify indexed existing files and redownload only missing, stale, mismatched or corrupt pages.
 - `skip` — reuse only files that can be verified from the provenance index; ambiguous unverified files are never silently accepted.
+
+For scripts and unattended runs, select an explicit non-interactive policy instead of `ask`, for example `--existing resume` or `--existing error`.
 
 The same source canvas receives the same planned filename regardless of the selected subset, worker count or completion order. For example, a 150-page gallery uses names such as `pag-001.jpg`; downloading only pages 7–12 still produces the corresponding zero-padded names from the complete gallery.
 
@@ -107,7 +150,7 @@ These checks improve local integrity; they do not cryptographically authenticate
 | Worker count | yes | yes |
 | Descriptive filenames | yes | yes |
 | Exact output directory | yes | yes |
-| Existing-output policy | yes | yes |
+| Existing-output policy / ask | yes | yes |
 | Verified resume | yes | yes |
 | Shared validation/reporting | yes | yes |
 | Dry-run preview | yes | not yet |
@@ -116,7 +159,7 @@ Dry-run is currently a CLI review surface; the underlying download plan is share
 
 ## Graphical interface
 
-Launch:
+If you downloaded a standalone release executable, launch that application directly. If you installed from PyPI, launch:
 
 ```text
 antenati-gui
@@ -124,7 +167,7 @@ antenati-gui
 
 ![GUI Screenshot](https://raw.githubusercontent.com/gcerretani/antenati/master/docs/gui_screenshot.png)
 
-Paste a gallery/manifest URL, choose the **exact destination directory**, then select the page range, image size, thread count, descriptive-name option and existing-output policy. The GUI runs the same downloader configuration, validation and result model as the CLI.
+Paste a gallery/manifest URL, choose the **exact destination directory**, then select the page range, image size, thread count, descriptive-name option and existing-output policy. The default `ask` policy prompts when the destination already contains files and recommends verified resume. The GUI runs the same downloader configuration, validation and result model as the CLI.
 
 ## AWS WAF and live-site limitations
 

--- a/src/antenati/__init__.py
+++ b/src/antenati/__init__.py
@@ -15,15 +15,16 @@ __contact__ = 'https://gcerretani.github.io/antenati/'
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:
-    # The package is being executed from a source checkout that hasn't
-    # been `pip install`-ed; report a sentinel so tests can still
-    # assert the attribute exists without pretending to know the tag.
     __version__ = '0.0.0+local'
 
 from antenati.downloader import (
     DEFAULT_N_THREADS,
     DEFAULT_SIZE,
+    DownloadItem,
+    DownloadPlan,
+    DownloadReport,
     Downloader,
+    PageFailure,
     ProgressBar,
 )
 from antenati.errors import ThreadError
@@ -31,7 +32,11 @@ from antenati.errors import ThreadError
 __all__ = [
     'DEFAULT_N_THREADS',
     'DEFAULT_SIZE',
+    'DownloadItem',
+    'DownloadPlan',
+    'DownloadReport',
     'Downloader',
+    'PageFailure',
     'ProgressBar',
     'ThreadError',
     '__author__',

--- a/src/antenati/__init__.py
+++ b/src/antenati/__init__.py
@@ -20,10 +20,10 @@ except PackageNotFoundError:
 from antenati.downloader import (
     DEFAULT_N_THREADS,
     DEFAULT_SIZE,
+    Downloader,
     DownloadItem,
     DownloadPlan,
     DownloadReport,
-    Downloader,
     PageFailure,
     ProgressBar,
 )

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 
 from antenati import __copyright__, __version__
 from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadReport, Downloader, ProgressBar
+from antenati.validation import DownloadOptions
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -25,7 +26,6 @@ def _configure_logging(verbosity: int) -> None:
 
 
 def run_cli(downloader: Downloader, n_workers: int, size: int) -> DownloadReport:
-    """Run the download with a tqdm progress bar attached."""
     with tqdm(unit='img') as progress:
         progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore[arg-type]
         return downloader.run(n_workers, size, progress_bar)
@@ -51,17 +51,18 @@ def main() -> None:
     parser.add_argument('-n', '--nthreads', type=int, default=DEFAULT_N_THREADS, help='max n. of threads')
     parser.add_argument('-f', '--first', type=int, default=0, help='first image to download')
     parser.add_argument('-l', '--last', type=int, default=None, help='first image NOT to download')
-    parser.add_argument('-d', '--descriptive-names', action='store_true', help='include the archive and image IDs in the saved file names')
+    parser.add_argument('-d', '--descriptive-names', action='store_true', help='include the archive and image IDs in saved file names')
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('--verbose', action='count', default=0, help='increase logging verbosity (--verbose for INFO, twice for DEBUG)')
     args = parser.parse_args()
 
+    options = DownloadOptions(first=args.first, last=args.last, size=args.size, n_workers=args.nthreads).validate()
     _configure_logging(args.verbose)
-    downloader = Downloader(args.url, args.first, args.last, descriptive_names=args.descriptive_names)
+    downloader = Downloader(args.url, options.first, options.last, descriptive_names=args.descriptive_names)
     downloader.load()
     downloader.print_gallery_info()
     downloader.check_dir()
-    report = run_cli(downloader, args.nthreads, args.size)
+    report = run_cli(downloader, options.n_workers, options.size)
     _print_report(report)
     if report.cancelled or report.failed or not report.successful:
         raise SystemExit(1)

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 
 from antenati import __copyright__, __version__
 from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadItem, DownloadReport, Downloader, ProgressBar
+from antenati.output import ExistingPolicy, prepare_output, run_with_policy
 from antenati.validation import DownloadOptions
 
 
@@ -27,14 +28,13 @@ def _configure_logging(verbosity: int) -> None:
     logging.basicConfig(level=level, format='%(levelname)s %(name)s: %(message)s')
 
 
-def run_cli(downloader: Downloader, n_workers: int, size: int) -> DownloadReport:
+def run_cli(downloader: Downloader, n_workers: int, size: int, policy: ExistingPolicy = ExistingPolicy.OVERWRITE) -> DownloadReport:
     with tqdm(unit='img') as progress:
         progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore[arg-type]
-        return downloader.run(n_workers, size, progress_bar)
+        return run_with_policy(downloader, n_workers=n_workers, size=size, progress=progress_bar, policy=policy)
 
 
 def _planned_filename(item: DownloadItem) -> str:
-    """Return the filename implied by the IIIF request URL without fetching it."""
     suffix = Path(urlsplit(item.source_url).path).suffix.lower()
     if suffix in {'.jpeg', '.jpe'}:
         suffix = '.jpg'
@@ -44,7 +44,6 @@ def _planned_filename(item: DownloadItem) -> str:
 
 
 def print_preview(downloader: Downloader, size: int) -> None:
-    """Print the exact planned canvases without creating files or fetching images."""
     plan = downloader.plan(size)
     print(f'Preview: {plan.expected} images -> {downloader.dirname}')
     for index, item in enumerate(plan.items, start=1):
@@ -74,21 +73,31 @@ def main() -> None:
     parser.add_argument('-f', '--first', type=int, default=0, help='first image to download')
     parser.add_argument('-l', '--last', type=int, default=None, help='first image NOT to download')
     parser.add_argument('-d', '--descriptive-names', action='store_true', help='include the archive and image IDs in saved file names')
+    parser.add_argument('-o', '--output', type=Path, default=None, help='exact output directory (default: generated archive directory)')
+    parser.add_argument(
+        '--existing',
+        choices=[policy.value for policy in ExistingPolicy],
+        default=ExistingPolicy.ERROR.value,
+        help='existing-file policy: error, overwrite, skip verified files without replacing unverified ones, or verified resume',
+    )
     parser.add_argument('--dry-run', action='store_true', help='show the resolved download plan without downloading image bodies or writing files')
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('--verbose', action='count', default=0, help='increase logging verbosity (--verbose for INFO, twice for DEBUG)')
     args = parser.parse_args()
 
     options = DownloadOptions(first=args.first, last=args.last, size=args.size, n_workers=args.nthreads).validate()
+    policy = ExistingPolicy(args.existing)
     _configure_logging(args.verbose)
     downloader = Downloader(args.url, options.first, options.last, descriptive_names=args.descriptive_names)
     downloader.load()
+    if args.output is not None:
+        downloader.dirname = args.output
     if args.dry_run:
         print_preview(downloader, options.size)
         return
     downloader.print_gallery_info()
-    downloader.check_dir()
-    report = run_cli(downloader, options.n_workers, options.size)
+    prepare_output(downloader, args.output, policy)
+    report = run_cli(downloader, options.n_workers, options.size, policy)
     _print_report(report)
     if report.cancelled or report.failed or not report.successful:
         raise SystemExit(1)

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -10,13 +10,14 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 from urllib.parse import urlsplit
 
+import click
 from humanize import naturalsize
 from tqdm import tqdm
 
 from antenati import __copyright__, __version__
 from antenati.config import DownloadConfig
 from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, Downloader, DownloadItem, DownloadReport, ProgressBar
-from antenati.output import ExistingPolicy, prepare_output, run_with_policy
+from antenati.output import ExistingPolicy, existing_output_requires_decision, output_directory, prepare_output, run_with_policy
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -52,6 +53,29 @@ def print_preview(downloader: Downloader, size: int) -> None:
         print(f'{index:>5}  {_planned_filename(item)}  {label}  {canvas_id}  {item.source_url}')
 
 
+def _resolve_cli_policy(downloader: Downloader, output: str | Path | None, policy: ExistingPolicy) -> ExistingPolicy:
+    """Resolve ``ask`` to a concrete policy before entering the downloader core."""
+    if policy is not ExistingPolicy.ASK or not existing_output_requires_decision(downloader, output):
+        return ExistingPolicy.ERROR if policy is ExistingPolicy.ASK else policy
+
+    directory = output_directory(downloader, output)
+    click.echo(f'Output directory already exists and is not empty: {directory}')
+    click.echo('Choose how to handle existing files:')
+    click.echo('  resume    verify and reuse valid downloads (recommended)')
+    click.echo('  overwrite download again and replace planned files')
+    click.echo('  skip      reuse verified files; refuse ambiguous existing files')
+    click.echo('  cancel    stop without changing the directory')
+    selected = click.prompt(
+        'Policy',
+        type=click.Choice(['resume', 'overwrite', 'skip', 'cancel'], case_sensitive=False),
+        default='resume',
+        show_choices=False,
+    ).lower()
+    if selected == 'cancel':
+        raise SystemExit(1)
+    return ExistingPolicy(selected)
+
+
 def _print_report(report: DownloadReport) -> None:
     print(
         f'Completed: {report.completed}/{report.expected}; skipped: {report.skipped}; '
@@ -77,8 +101,8 @@ def main() -> None:
     parser.add_argument(
         '--existing',
         choices=[policy.value for policy in ExistingPolicy],
-        default=ExistingPolicy.ERROR.value,
-        help='existing-file policy: error, overwrite, skip verified files without replacing unverified ones, or verified resume',
+        default=ExistingPolicy.ASK.value,
+        help='existing-file policy: ask, error, overwrite, skip verified files without replacing unverified ones, or verified resume',
     )
     parser.add_argument('--dry-run', action='store_true', help='show the resolved download plan without downloading image bodies or writing files')
     parser.add_argument('-v', '--version', action='version', version=__version__)
@@ -105,8 +129,9 @@ def main() -> None:
         print_preview(downloader, config.size)
         return
     downloader.print_gallery_info()
-    prepare_output(downloader, config.output_dir, config.existing_policy)
-    report = run_cli(downloader, config.n_workers, config.size, config.existing_policy)
+    policy = _resolve_cli_policy(downloader, config.output_dir, config.existing_policy)
+    prepare_output(downloader, config.output_dir, policy)
+    report = run_cli(downloader, config.n_workers, config.size, policy)
     _print_report(report)
     if report.cancelled or report.failed or not report.successful:
         raise SystemExit(1)

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -14,9 +14,9 @@ from humanize import naturalsize
 from tqdm import tqdm
 
 from antenati import __copyright__, __version__
+from antenati.config import DownloadConfig
 from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadItem, DownloadReport, Downloader, ProgressBar
 from antenati.output import ExistingPolicy, prepare_output, run_with_policy
-from antenati.validation import DownloadOptions
 
 
 def _configure_logging(verbosity: int) -> None:
@@ -85,19 +85,28 @@ def main() -> None:
     parser.add_argument('--verbose', action='count', default=0, help='increase logging verbosity (--verbose for INFO, twice for DEBUG)')
     args = parser.parse_args()
 
-    options = DownloadOptions(first=args.first, last=args.last, size=args.size, n_workers=args.nthreads).validate()
-    policy = ExistingPolicy(args.existing)
+    config = DownloadConfig(
+        url=args.url,
+        output_dir=str(args.output) if args.output is not None else None,
+        size=args.size,
+        first=args.first,
+        last=args.last,
+        n_workers=args.nthreads,
+        descriptive_names=args.descriptive_names,
+        existing_policy=ExistingPolicy(args.existing),
+        dry_run=args.dry_run,
+    ).validate()
     _configure_logging(args.verbose)
-    downloader = Downloader(args.url, options.first, options.last, descriptive_names=args.descriptive_names)
+    downloader = Downloader(config.url, config.first, config.last, descriptive_names=config.descriptive_names)
     downloader.load()
-    if args.output is not None:
-        downloader.dirname = args.output
-    if args.dry_run:
-        print_preview(downloader, options.size)
+    if config.output_dir is not None:
+        downloader.dirname = Path(config.output_dir)
+    if config.dry_run:
+        print_preview(downloader, config.size)
         return
     downloader.print_gallery_info()
-    prepare_output(downloader, args.output, policy)
-    report = run_cli(downloader, options.n_workers, options.size, policy)
+    prepare_output(downloader, config.output_dir, config.existing_policy)
+    report = run_cli(downloader, config.n_workers, config.size, config.existing_policy)
     _print_report(report)
     if report.cancelled or report.failed or not report.successful:
         raise SystemExit(1)

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from antenati import __copyright__, __version__
 from antenati.config import DownloadConfig
-from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadItem, DownloadReport, Downloader, ProgressBar
+from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, Downloader, DownloadItem, DownloadReport, ProgressBar
 from antenati.output import ExistingPolicy, prepare_output, run_with_policy
 
 

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 
 import logging
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from pathlib import Path
+from urllib.parse import urlsplit
 
 from humanize import naturalsize
 from tqdm import tqdm
 
 from antenati import __copyright__, __version__
-from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadReport, Downloader, ProgressBar
+from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadItem, DownloadReport, Downloader, ProgressBar
 from antenati.validation import DownloadOptions
 
 
@@ -29,6 +31,26 @@ def run_cli(downloader: Downloader, n_workers: int, size: int) -> DownloadReport
     with tqdm(unit='img') as progress:
         progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore[arg-type]
         return downloader.run(n_workers, size, progress_bar)
+
+
+def _planned_filename(item: DownloadItem) -> str:
+    """Return the filename implied by the IIIF request URL without fetching it."""
+    suffix = Path(urlsplit(item.source_url).path).suffix.lower()
+    if suffix in {'.jpeg', '.jpe'}:
+        suffix = '.jpg'
+    if suffix not in {'.jpg', '.png', '.tif', '.tiff', '.webp'}:
+        suffix = '.img'
+    return f'{item.stem}{suffix}'
+
+
+def print_preview(downloader: Downloader, size: int) -> None:
+    """Print the exact planned canvases without creating files or fetching images."""
+    plan = downloader.plan(size)
+    print(f'Preview: {plan.expected} images -> {downloader.dirname}')
+    for index, item in enumerate(plan.items, start=1):
+        canvas_id = str(item.canvas.get('@id', ''))
+        label = str(item.canvas.get('label', ''))
+        print(f'{index:>5}  {_planned_filename(item)}  {label}  {canvas_id}  {item.source_url}')
 
 
 def _print_report(report: DownloadReport) -> None:
@@ -52,6 +74,7 @@ def main() -> None:
     parser.add_argument('-f', '--first', type=int, default=0, help='first image to download')
     parser.add_argument('-l', '--last', type=int, default=None, help='first image NOT to download')
     parser.add_argument('-d', '--descriptive-names', action='store_true', help='include the archive and image IDs in saved file names')
+    parser.add_argument('--dry-run', action='store_true', help='show the resolved download plan without downloading image bodies or writing files')
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('--verbose', action='count', default=0, help='increase logging verbosity (--verbose for INFO, twice for DEBUG)')
     args = parser.parse_args()
@@ -60,6 +83,9 @@ def main() -> None:
     _configure_logging(args.verbose)
     downloader = Downloader(args.url, options.first, options.last, descriptive_names=args.descriptive_names)
     downloader.load()
+    if args.dry_run:
+        print_preview(downloader, options.size)
+        return
     downloader.print_gallery_info()
     downloader.check_dir()
     report = run_cli(downloader, options.n_workers, options.size)

--- a/src/antenati/cli.py
+++ b/src/antenati/cli.py
@@ -12,16 +12,10 @@ from humanize import naturalsize
 from tqdm import tqdm
 
 from antenati import __copyright__, __version__
-from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, Downloader, ProgressBar
+from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE, DownloadReport, Downloader, ProgressBar
 
 
 def _configure_logging(verbosity: int) -> None:
-    """Configure the root logger from a --verbose count.
-
-    Default (no flag) keeps the historical behaviour: only WARNING and
-    above are visible. ``--verbose`` raises to INFO; passing it twice
-    enables DEBUG (including each HTTP request).
-    """
     level = logging.WARNING
     if verbosity >= 2:
         level = logging.DEBUG
@@ -30,11 +24,20 @@ def _configure_logging(verbosity: int) -> None:
     logging.basicConfig(level=level, format='%(levelname)s %(name)s: %(message)s')
 
 
-def run_cli(downloader: Downloader, n_workers: int, size: int) -> int:
+def run_cli(downloader: Downloader, n_workers: int, size: int) -> DownloadReport:
     """Run the download with a tqdm progress bar attached."""
     with tqdm(unit='img') as progress:
         progress_bar = ProgressBar(progress.reset, progress.update)  # type: ignore[arg-type]
         return downloader.run(n_workers, size, progress_bar)
+
+
+def _print_report(report: DownloadReport) -> None:
+    print(
+        f'Completed: {report.completed}/{report.expected}; skipped: {report.skipped}; '
+        f'failed: {len(report.failed)}; bytes written: {naturalsize(report.bytes_written, True)}'
+    )
+    for failure in report.failed:
+        print(f' - {failure.label}: {failure.reason}')
 
 
 def main() -> None:
@@ -44,55 +47,24 @@ def main() -> None:
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument('url', metavar='URL', type=str, help='url of the gallery page or of its IIIF manifest')
-    parser.add_argument(
-        '-s',
-        '--size',
-        type=int,
-        default=DEFAULT_SIZE,
-        help='image size in pixel (0 means full size)',
-    )
-    parser.add_argument(
-        '-n',
-        '--nthreads',
-        type=int,
-        default=DEFAULT_N_THREADS,
-        help='max n. of threads',
-    )
-    parser.add_argument(
-        '-f',
-        '--first',
-        type=int,
-        default=0,
-        help='first image to download',
-    )
-    parser.add_argument(
-        '-l',
-        '--last',
-        type=int,
-        default=None,
-        help='first image NOT to download',
-    )
-    parser.add_argument(
-        '-d',
-        '--descriptive-names',
-        action='store_true',
-        help='include the archive and image IDs in the saved file names',
-    )
+    parser.add_argument('-s', '--size', type=int, default=DEFAULT_SIZE, help='image size in pixel (0 means full size)')
+    parser.add_argument('-n', '--nthreads', type=int, default=DEFAULT_N_THREADS, help='max n. of threads')
+    parser.add_argument('-f', '--first', type=int, default=0, help='first image to download')
+    parser.add_argument('-l', '--last', type=int, default=None, help='first image NOT to download')
+    parser.add_argument('-d', '--descriptive-names', action='store_true', help='include the archive and image IDs in the saved file names')
     parser.add_argument('-v', '--version', action='version', version=__version__)
-    parser.add_argument(
-        '--verbose',
-        action='count',
-        default=0,
-        help='increase logging verbosity (--verbose for INFO, --verbose --verbose for DEBUG)',
-    )
+    parser.add_argument('--verbose', action='count', default=0, help='increase logging verbosity (--verbose for INFO, twice for DEBUG)')
     args = parser.parse_args()
 
     _configure_logging(args.verbose)
     downloader = Downloader(args.url, args.first, args.last, descriptive_names=args.descriptive_names)
+    downloader.load()
     downloader.print_gallery_info()
     downloader.check_dir()
-    gallery_size = run_cli(downloader, args.nthreads, args.size)
-    print(f'Done. Total size: {naturalsize(gallery_size, True)}')
+    report = run_cli(downloader, args.nthreads, args.size)
+    _print_report(report)
+    if report.cancelled or report.failed or not report.successful:
+        raise SystemExit(1)
 
 
 if __name__ == '__main__':

--- a/src/antenati/config.py
+++ b/src/antenati/config.py
@@ -22,7 +22,7 @@ class DownloadConfig:
     last: int | None = None
     n_workers: int = 2
     descriptive_names: bool = False
-    existing_policy: ExistingPolicy = ExistingPolicy.ERROR
+    existing_policy: ExistingPolicy = ExistingPolicy.ASK
     dry_run: bool = False
 
     def options(self) -> DownloadOptions:

--- a/src/antenati/config.py
+++ b/src/antenati/config.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2018 Giovanni Cerretani
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Shared download configuration used by CLI and GUI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from antenati.errors import ValidationError
+from antenati.output import ExistingPolicy
+from antenati.validation import DownloadOptions
+
+
+@dataclass
+class DownloadConfig:
+    """Interface-independent user configuration for one gallery run."""
+
+    url: str
+    output_dir: str | None = None
+    size: int = 0
+    first: int = 0
+    last: int | None = None
+    n_workers: int = 2
+    descriptive_names: bool = False
+    existing_policy: ExistingPolicy = ExistingPolicy.ERROR
+    dry_run: bool = False
+
+    def options(self) -> DownloadOptions:
+        return DownloadOptions(first=self.first, last=self.last, size=self.size, n_workers=self.n_workers)
+
+    def validate(self, *, require_output: bool = False) -> DownloadConfig:
+        self.options().validate()
+        if not self.url.strip():
+            raise ValidationError('url must not be empty')
+        if require_output and (self.output_dir is None or not self.output_dir.strip()):
+            raise ValidationError('output directory must not be empty')
+        return self

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -3,14 +3,9 @@
 """Core download orchestration for the Portale Antenati.
 
 The downloader lifecycle is deliberately split into explicit phases:
-
-1. construct a :class:`Downloader` (configuration only; no network I/O),
-2. :meth:`Downloader.load` the source manifest,
-3. :meth:`Downloader.plan` the selected canvases and deterministic filenames,
-4. :meth:`Downloader.run` the resulting plan.
-
-Keeping construction side-effect free makes validation, preview and testing
-possible without accidentally touching the network or filesystem.
+construct configuration, load the manifest, build a deterministic plan, then
+execute it. Execution returns a structured :class:`DownloadReport` shared by
+CLI and GUI callers.
 """
 
 from __future__ import annotations
@@ -19,7 +14,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from dataclasses import dataclass
 from json import loads
@@ -72,13 +67,37 @@ class DownloadPlan:
         return len(self.items)
 
 
-class Downloader:
-    """Plan and execute a Portale Antenati gallery download.
+@dataclass(frozen=True)
+class PageFailure:
+    """Failure associated with one planned page."""
 
-    Construction stores configuration only. Accessing loaded properties such
-    as :attr:`manifest` remains backward compatible by loading lazily, while
-    new callers can use :meth:`load` and :meth:`plan` explicitly.
-    """
+    label: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DownloadReport:
+    """Complete outcome of one execution attempt."""
+
+    expected: int
+    attempted: int
+    completed: int
+    skipped: int
+    failed: tuple[PageFailure, ...]
+    cancelled: bool
+    bytes_written: int
+
+    @property
+    def successful(self) -> bool:
+        return not self.cancelled and not self.failed and self.completed + self.skipped == self.expected
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.expected - self.completed - self.skipped - len(self.failed))
+
+
+class Downloader:
+    """Plan and execute a Portale Antenati gallery download."""
 
     def __init__(self, url: str, first: int, last: int | None, descriptive_names: bool = False):
         self.url = url
@@ -284,31 +303,50 @@ class Downloader:
                 with suppress(FileNotFoundError):
                     os.unlink(temp_name)
 
-    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel: threading.Event | None = None) -> int:
-        """Execute the selected plan and return the number of bytes written."""
+    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel: threading.Event | None = None) -> DownloadReport:
+        """Execute the selected plan and return a structured outcome report."""
         plan = self.plan(size)
         progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():
             logger.info('Download cancelled before any work was submitted')
-            return 0
+            return DownloadReport(plan.expected, 0, 0, 0, (), True, 0)
+
+        attempted = 0
+        completed = 0
+        bytes_written = 0
+        failures: list[PageFailure] = []
+        cancelled = False
 
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
             futures = {executor.submit(self._thread_main, item, cancel) for item in plan.items}
-            gallery_size = 0
-            failed: list[tuple[str, str]] = []
             for future in as_completed(futures):
                 if cancel is not None and cancel.is_set():
+                    cancelled = True
                     for pending in futures:
                         pending.cancel()
-                    logger.info('Download cancelled by caller')
-                    return gallery_size
+                if future.cancelled():
+                    continue
+                attempted += 1
                 progress.update()
                 try:
-                    gallery_size += future.result()
+                    written = future.result()
+                except CancelledError:
+                    cancelled = True
                 except ThreadError as ex:
-                    failed.append((ex.label, str(ex.__cause__)))
-            if failed:
-                msg = f'Failed to download {len(failed)} images:\n'
-                msg += '\n - '.join(f'{label}: {reason}' for label, reason in failed)
-                raise RuntimeError(msg)
-            return gallery_size
+                    failures.append(PageFailure(ex.label, str(ex.__cause__)))
+                else:
+                    if written > 0:
+                        completed += 1
+                        bytes_written += written
+                    elif cancel is not None and cancel.is_set():
+                        cancelled = True
+
+        return DownloadReport(
+            expected=plan.expected,
+            attempted=attempted,
+            completed=completed,
+            skipped=0,
+            failed=tuple(failures),
+            cancelled=cancelled,
+            bytes_written=bytes_written,
+        )

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -21,6 +21,7 @@ from json import loads
 from mimetypes import guess_extension
 from os import mkdir, path
 from pathlib import Path
+from re import finditer
 from sys import exit as sys_exit
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -193,7 +194,11 @@ class Downloader:
         all_stems = self._build_unique_stems(self._all_canvases)
         selected_stems = all_stems[self.first : self.last]
         items = tuple(
-            DownloadItem(canvas=canvas, stem=stem, source_url=iiif.manipulate_image_url(iiif.image_url_for_canvas(canvas), size))
+            DownloadItem(
+                canvas=canvas,
+                stem=stem,
+                source_url=iiif.manipulate_image_url(iiif.image_url_for_canvas(canvas), size),
+            )
             for canvas, stem in zip(self._canvases, selected_stems, strict=True)
         )
         self._plan = DownloadPlan(items=items, size=size)
@@ -227,12 +232,25 @@ class Downloader:
         typology = iiif.get_metadata_value(manifest, iiif.META_TYPOLOGY)
         return Path(slugify(f'{context}-{year}-{typology}-{archive_id}'))
 
+    @staticmethod
+    def _pad_numeric_label(label: str, width: int) -> str:
+        """Pad the last numeric component while preserving label semantics."""
+        matches = list(finditer(r'\d+', label))
+        if not matches:
+            return label
+        match = matches[-1]
+        number = match.group(0).zfill(width)
+        return f'{label[: match.start()]}{number}{label[match.end() :]}'
+
     def _build_unique_stems(self, canvases: list[dict[str, Any]]) -> list[str]:
-        """Return stable, collision-free output stems for canvases."""
+        """Return stable, collision-free and lexicographically sortable stems."""
         used: set[str] = set()
         result: list[str] = []
+        width = len(str(len(canvases)))
         for index, canvas in enumerate(canvases, start=1):
-            label = slugify(str(canvas.get('label', ''))) or f'image-{index}'
+            raw_label = str(canvas.get('label', ''))
+            padded_label = self._pad_numeric_label(raw_label, width)
+            label = slugify(padded_label) or f'image-{index:0{width}d}'
             base = label
             if self.descriptive_names:
                 image_url = iiif.image_url_for_canvas(canvas)
@@ -285,7 +303,13 @@ class Downloader:
                 raise RuntimeError(f'{item.source_url}: Unable to guess extension "{content_type}"')
             filename = self.dirname / f'{item.stem}{extension}'
 
-            with NamedTemporaryFile(mode='wb', dir=self.dirname, prefix=f'.{item.stem}.', suffix='.tmp', delete=False) as img_file:
+            with NamedTemporaryFile(
+                mode='wb',
+                dir=self.dirname,
+                prefix=f'.{item.stem}.',
+                suffix='.tmp',
+                delete=False,
+            ) as img_file:
                 temp_name = img_file.name
                 img_file.write(http_reply.content)
                 img_file.flush()
@@ -303,7 +327,13 @@ class Downloader:
                 with suppress(FileNotFoundError):
                     os.unlink(temp_name)
 
-    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel: threading.Event | None = None) -> DownloadReport:
+    def run(
+        self,
+        n_workers: int,
+        size: int,
+        progress: ProgressBar,
+        cancel: threading.Event | None = None,
+    ) -> DownloadReport:
         """Execute the selected plan and return a structured outcome report."""
         plan = self.plan(size)
         progress.set_total(plan.expected)

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Core download orchestration for the Portale Antenati.
 
-The :class:`Downloader` is the main entry point used by both the CLI
-(:mod:`antenati.cli`) and the GUI (:mod:`antenati.gui`). It composes the
-side-effect-free helpers from :mod:`antenati.iiif` with the HTTP session
-built in :mod:`antenati.http`, and runs per-canvas image downloads in a
-thread pool.
+The downloader lifecycle is deliberately split into explicit phases:
 
-Keeping orchestration separate from CLI/GUI plumbing makes the downloader
-usable from third-party scripts and keeps network, parsing and presentation
-concerns reasonably isolated.
+1. construct a :class:`Downloader` (configuration only; no network I/O),
+2. :meth:`Downloader.load` the source manifest,
+3. :meth:`Downloader.plan` the selected canvases and deterministic filenames,
+4. :meth:`Downloader.run` the resulting plan.
+
+Keeping construction side-effect free makes validation, preview and testing
+possible without accidentally touching the network or filesystem.
 """
 
 from __future__ import annotations
@@ -45,62 +45,143 @@ DEFAULT_N_THREADS: int = 2
 
 @dataclass
 class ProgressBar:
-    """Callback pair used to drive a progress indicator.
-
-    Both callbacks are invoked by the orchestration thread. CLI callers can
-    update counters directly; GUI callers can marshal updates to their UI
-    thread inside the callbacks.
-    """
+    """Callback pair used to drive a progress indicator."""
 
     set_total: Callable[[int], None]
     update: Callable[[], None]
 
 
-class Downloader:
-    """Download a Portale Antenati gallery to disk."""
+@dataclass(frozen=True)
+class DownloadItem:
+    """One planned canvas download, independent from execution order."""
 
-    url: str
-    session: Session
-    descriptive_names: bool
-    manifest: dict[str, Any]
-    canvases: list[dict[str, Any]]
-    archive_id: str
-    ark_id: str
-    dirname: Path
-    gallery_length: int
+    canvas: dict[str, Any]
+    stem: str
+    source_url: str
+
+
+@dataclass(frozen=True)
+class DownloadPlan:
+    """Immutable execution plan produced from a loaded manifest."""
+
+    items: tuple[DownloadItem, ...]
+    size: int
+
+    @property
+    def expected(self) -> int:
+        return len(self.items)
+
+
+class Downloader:
+    """Plan and execute a Portale Antenati gallery download.
+
+    Construction stores configuration only. Accessing loaded properties such
+    as :attr:`manifest` remains backward compatible by loading lazily, while
+    new callers can use :meth:`load` and :meth:`plan` explicitly.
+    """
 
     def __init__(self, url: str, first: int, last: int | None, descriptive_names: bool = False):
         self.url = url
-        self.session = http.build_session()
+        self.first = first
+        self.last = last
         self.descriptive_names = descriptive_names
+        self.session: Session = http.build_session()
 
-        # Gallery URLs embed the archive ID in their ARK path, so validate and
-        # extract it before the first network request. A direct manifest URL
-        # does not necessarily contain that identifier; in that case it is
-        # recovered from the first selected canvas after loading the manifest.
-        archive_id = None if iiif.is_manifest_url(url) else iiif.get_archive_id_from_url(url)
-        logger.info('Loading manifest from %s', url)
-        self.manifest = self.__load_manifest()
-        self.canvases = iiif.slice_canvases(self.manifest, first, last)
-        self.archive_id = archive_id if archive_id is not None else iiif.get_archive_id_from_canvases(self.canvases)
-        self.ark_id = self.__resolve_ark_id()
-        self.dirname = self.__generate_dirname()
-        self.gallery_length = len(self.canvases)
+        self._manifest: dict[str, Any] | None = None
+        self._manifest_url: str | None = None
+        self._all_canvases: list[dict[str, Any]] | None = None
+        self._canvases: list[dict[str, Any]] | None = None
+        self._archive_id: str | None = None
+        self._ark_id: str | None = None
+        self._dirname: Path | None = None
+        self._plan: DownloadPlan | None = None
 
-        # Plan names against the complete gallery, then apply the same slice
-        # used for the canvases. This keeps collision suffixes stable even if
-        # the user downloads the same pages later through a different range.
-        all_canvases = iiif.slice_canvases(self.manifest, 0, None)
-        all_stems = self.__build_unique_stems(all_canvases)
-        self._download_stems = all_stems[first:last]
-        logger.info('Manifest loaded: %d canvases selected', self.gallery_length)
+    @property
+    def manifest(self) -> dict[str, Any]:
+        self.load()
+        assert self._manifest is not None
+        return self._manifest
 
-    def __load_manifest(self) -> dict[str, Any]:
+    @property
+    def manifest_url(self) -> str:
+        self.load()
+        assert self._manifest_url is not None
+        return self._manifest_url
+
+    @property
+    def canvases(self) -> list[dict[str, Any]]:
+        self.load()
+        assert self._canvases is not None
+        return self._canvases
+
+    @property
+    def archive_id(self) -> str:
+        self.load()
+        assert self._archive_id is not None
+        return self._archive_id
+
+    @property
+    def ark_id(self) -> str:
+        self.load()
+        assert self._ark_id is not None
+        return self._ark_id
+
+    @property
+    def dirname(self) -> Path:
+        self.load()
+        assert self._dirname is not None
+        return self._dirname
+
+    @dirname.setter
+    def dirname(self, value: Path) -> None:
+        self._dirname = value
+
+    @property
+    def gallery_length(self) -> int:
+        return len(self.canvases)
+
+    def load(self) -> Downloader:
+        """Resolve and validate the source manifest without downloading images."""
+        if self._manifest is not None:
+            return self
+
+        archive_id = None if iiif.is_manifest_url(self.url) else iiif.get_archive_id_from_url(self.url)
+        logger.info('Loading manifest from %s', self.url)
+        manifest, manifest_url = self._load_manifest()
+        all_canvases = iiif.slice_canvases(manifest, 0, None)
+        canvases = iiif.slice_canvases(manifest, self.first, self.last)
+        if archive_id is None:
+            archive_id = iiif.get_archive_id_from_canvases(all_canvases)
+
+        self._manifest = manifest
+        self._manifest_url = manifest_url
+        self._all_canvases = all_canvases
+        self._canvases = canvases
+        self._archive_id = archive_id
+        self._ark_id = self._resolve_ark_id(canvases, archive_id)
+        self._dirname = self._generate_dirname(manifest, archive_id)
+        logger.info('Manifest loaded: %d canvases selected', len(canvases))
+        return self
+
+    def plan(self, size: int = DEFAULT_SIZE) -> DownloadPlan:
+        """Build a deterministic image plan without image/network writes."""
+        self.load()
+        if self._plan is not None and self._plan.size == size:
+            return self._plan
+        assert self._all_canvases is not None
+        assert self._canvases is not None
+
+        all_stems = self._build_unique_stems(self._all_canvases)
+        selected_stems = all_stems[self.first : self.last]
+        items = tuple(
+            DownloadItem(canvas=canvas, stem=stem, source_url=iiif.manipulate_image_url(iiif.image_url_for_canvas(canvas), size))
+            for canvas, stem in zip(self._canvases, selected_stems, strict=True)
+        )
+        self._plan = DownloadPlan(items=items, size=size)
+        return self._plan
+
+    def _load_manifest(self) -> tuple[dict[str, Any], str]:
         if iiif.is_manifest_url(self.url):
-            # The direct IIIF manifest is a useful alternate entry point when
-            # the public gallery HTML is blocked by the AWS WAF (issue #25).
-            # Keeping this path explicit also avoids scraping HTML when the
-            # caller already knows the canonical manifest URL.
             manifest_url = self.url
         else:
             gallery_reply = http.fetch(self.session, self.url)
@@ -110,33 +191,28 @@ class Downloader:
         logger.debug('Manifest URL: %s', manifest_url)
         manifest_reply = http.fetch(self.session, manifest_url)
         manifest_charset = http.get_content_charset(manifest_reply) or 'utf-8'
-        return loads(manifest_reply.content.decode(manifest_charset))
+        return loads(manifest_reply.content.decode(manifest_charset)), manifest_url
 
-    def __resolve_ark_id(self) -> str:
-        first_canvas_url = str(self.canvases[0].get('@id', ''))
+    def _resolve_ark_id(self, canvases: list[dict[str, Any]], archive_id: str) -> str:
+        first_canvas_url = str(canvases[0].get('@id', ''))
         for candidate in (self.url, first_canvas_url):
             ark = iiif.get_ark_id_from_url(candidate)
             if ark:
                 return ark
-        return self.archive_id
+        return archive_id
 
-    def __generate_dirname(self) -> Path:
-        context = iiif.get_metadata_value(self.manifest, iiif.META_CONTEXT)
-        year = iiif.get_metadata_value(self.manifest, iiif.META_TITLE)
-        typology = iiif.get_metadata_value(self.manifest, iiif.META_TYPOLOGY)
-        return Path(slugify(f'{context}-{year}-{typology}-{self.archive_id}'))
+    @staticmethod
+    def _generate_dirname(manifest: dict[str, Any], archive_id: str) -> Path:
+        context = iiif.get_metadata_value(manifest, iiif.META_CONTEXT)
+        year = iiif.get_metadata_value(manifest, iiif.META_TITLE)
+        typology = iiif.get_metadata_value(manifest, iiif.META_TYPOLOGY)
+        return Path(slugify(f'{context}-{year}-{typology}-{archive_id}'))
 
-    def __build_unique_stems(self, canvases: list[dict[str, Any]] | None = None) -> list[str]:
-        """Return stable, collision-free output stems for canvases.
-
-        Historical/default filenames remain unchanged unless two canvases
-        would otherwise resolve to the same path. In that exceptional case
-        only later duplicates receive ``-2``, ``-3`` ... suffixes.
-        """
-        source_canvases = self.canvases if canvases is None else canvases
+    def _build_unique_stems(self, canvases: list[dict[str, Any]]) -> list[str]:
+        """Return stable, collision-free output stems for canvases."""
         used: set[str] = set()
         result: list[str] = []
-        for index, canvas in enumerate(source_canvases, start=1):
+        for index, canvas in enumerate(canvases, start=1):
             label = slugify(str(canvas.get('label', ''))) or f'image-{index}'
             base = label
             if self.descriptive_names:
@@ -161,8 +237,9 @@ class Downloader:
 
     def check_dir(self, parentdir: str | None = None, interactive: bool = True) -> None:
         """Ensure the output directory exists, prompting the user on conflict."""
+        current = self.dirname
         if parentdir is not None:
-            self.dirname = Path(parentdir) / self.dirname
+            self.dirname = Path(parentdir) / current
         print(f'Output directory: {self.dirname}')
         if path.exists(self.dirname):
             msg = f'Directory {self.dirname} already exists.'
@@ -174,39 +251,22 @@ class Downloader:
         else:
             mkdir(self.dirname)
 
-    def __thread_main(
-        self,
-        canvas: dict[str, Any],
-        stem: str,
-        size: int,
-        cancel: threading.Event | None,
-    ) -> int:
-        label = slugify(str(canvas.get('label', ''))) or stem
+    def _thread_main(self, item: DownloadItem, cancel: threading.Event | None) -> int:
+        label = slugify(str(item.canvas.get('label', ''))) or item.stem
         temp_name: str | None = None
         try:
             if cancel is not None and cancel.is_set():
                 return 0
-            image_url = iiif.image_url_for_canvas(canvas)
-            url = iiif.manipulate_image_url(image_url, size)
-            http_reply = http.fetch(self.session, url)
+            http_reply = http.fetch(self.session, item.source_url)
             if cancel is not None and cancel.is_set():
                 return 0
             content_type = http.get_content_type(http_reply)
             extension = guess_extension(content_type)
             if not extension:
-                raise RuntimeError(f'{url}: Unable to guess extension "{content_type}"')
-            filename = self.dirname / f'{stem}{extension}'
+                raise RuntimeError(f'{item.source_url}: Unable to guess extension "{content_type}"')
+            filename = self.dirname / f'{item.stem}{extension}'
 
-            # Write in the destination directory so os.replace() stays on the
-            # same filesystem and is atomic. The final path is touched only
-            # after the whole response has been written and flushed.
-            with NamedTemporaryFile(
-                mode='wb',
-                dir=self.dirname,
-                prefix=f'.{stem}.',
-                suffix='.tmp',
-                delete=False,
-            ) as img_file:
+            with NamedTemporaryFile(mode='wb', dir=self.dirname, prefix=f'.{item.stem}.', suffix='.tmp', delete=False) as img_file:
                 temp_name = img_file.name
                 img_file.write(http_reply.content)
                 img_file.flush()
@@ -220,41 +280,26 @@ class Downloader:
             logger.warning('Image %s failed: %s', label, ex)
             raise ThreadError(label) from ex
         finally:
-            # Cancellation and failures must not leave temporary files that
-            # look like completed downloads on a subsequent run.
             if temp_name is not None:
                 with suppress(FileNotFoundError):
                     os.unlink(temp_name)
 
-    def run(
-        self,
-        n_workers: int,
-        size: int,
-        progress: ProgressBar,
-        cancel: threading.Event | None = None,
-    ) -> int:
-        """Download all selected canvases concurrently and return bytes written.
-
-        A cancellation that is already set prevents any image work from being
-        submitted. During an active run, queued futures are cancelled when
-        possible; workers already inside an HTTP request rely on the bounded
-        connect/read timeouts in :mod:`antenati.http` before they can return.
-        """
-        progress.set_total(self.gallery_length)
+    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel: threading.Event | None = None) -> int:
+        """Execute the selected plan and return the number of bytes written."""
+        plan = self.plan(size)
+        progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():
             logger.info('Download cancelled before any work was submitted')
             return 0
 
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            future_img = {
-                executor.submit(self.__thread_main, canvas, stem, size, cancel) for canvas, stem in zip(self.canvases, self._download_stems, strict=True)
-            }
+            futures = {executor.submit(self._thread_main, item, cancel) for item in plan.items}
             gallery_size = 0
             failed: list[tuple[str, str]] = []
-            for future in as_completed(future_img):
+            for future in as_completed(futures):
                 if cancel is not None and cancel.is_set():
-                    for f in future_img:
-                        f.cancel()
+                    for pending in futures:
+                        pending.cancel()
                     logger.info('Download cancelled by caller')
                     return gallery_size
                 progress.update()

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -145,10 +145,8 @@ class Downloader:
         return len(self.canvases)
 
     def load(self) -> Downloader:
-        """Resolve and validate the source manifest without downloading images."""
         if self._manifest is not None:
             return self
-
         archive_id = None if iiif.is_manifest_url(self.url) else iiif.get_archive_id_from_url(self.url)
         logger.info('Loading manifest from %s', self.url)
         manifest, manifest_url = self._load_manifest()
@@ -156,7 +154,6 @@ class Downloader:
         canvases = iiif.slice_canvases(manifest, self.first, self.last)
         if archive_id is None:
             archive_id = iiif.get_archive_id_from_canvases(all_canvases)
-
         self._manifest = manifest
         self._manifest_url = manifest_url
         self._all_canvases = all_canvases
@@ -168,13 +165,11 @@ class Downloader:
         return self
 
     def plan(self, size: int = DEFAULT_SIZE) -> DownloadPlan:
-        """Build a deterministic image plan without image/network writes."""
         self.load()
         if self._plan is not None and self._plan.size == size:
             return self._plan
         assert self._all_canvases is not None
         assert self._canvases is not None
-
         all_stems = self._build_unique_stems(self._all_canvases)
         selected_stems = all_stems[self.first : self.last]
         items = tuple(
@@ -226,7 +221,6 @@ class Downloader:
         return f'{label[: match.start()]}{number}{label[match.end() :]}'
 
     def _build_unique_stems(self, canvases: list[dict[str, Any]]) -> list[str]:
-        """Return stable, collision-free and lexicographically sortable stems."""
         used: set[str] = set()
         result: list[str] = []
         width = len(str(len(canvases)))
@@ -267,6 +261,10 @@ class Downloader:
         else:
             mkdir(self.dirname)
 
+    @staticmethod
+    def _resume_key(item: DownloadItem) -> tuple[str, str]:
+        return str(item.canvas.get('@id', '')), item.source_url
+
     def _thread_main(self, item: DownloadItem, size: int, cancel: threading.Event | None) -> provenance.ImageRecord:
         label = slugify(str(item.canvas.get('label', ''))) or item.stem
         temp_name: str | None = None
@@ -282,7 +280,6 @@ class Downloader:
                 raise RuntimeError(f'{item.source_url}: Unable to guess extension "{content_type}"')
             filename = self.dirname / f'{item.stem}{extension}'
             content = http_reply.content
-
             with NamedTemporaryFile(
                 mode='wb',
                 dir=self.dirname,
@@ -335,27 +332,44 @@ class Downloader:
         size: int,
         progress: ProgressBar,
         cancel: threading.Event | None = None,
+        *,
+        resume: bool = False,
     ) -> DownloadReport:
+        """Execute a plan, optionally reusing only hash-verified indexed files."""
         plan = self.plan(size)
         progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():
-            logger.info('Download cancelled before any work was submitted')
+            logger.info('Download cancelled before any image work was submitted')
             return DownloadReport(plan.expected, 0, 0, 0, (), True, 0)
+
+        verified = (
+            provenance.verified_resume_records(self.dirname, manifest_url=self.manifest_url, requested_size=size) if resume else {}
+        )
+        records: list[provenance.ImageRecord] = []
+        pending: list[DownloadItem] = []
+        skipped = 0
+        for item in plan.items:
+            existing = verified.get(self._resume_key(item))
+            if existing is None:
+                pending.append(item)
+            else:
+                records.append(existing)
+                skipped += 1
+                progress.update()
 
         attempted = 0
         completed = 0
         bytes_written = 0
         failures: list[PageFailure] = []
-        records: list[provenance.ImageRecord] = []
         cancelled = False
 
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            futures = {executor.submit(self._thread_main, item, size, cancel) for item in plan.items}
+            futures = {executor.submit(self._thread_main, item, size, cancel) for item in pending}
             for future in as_completed(futures):
                 if cancel is not None and cancel.is_set():
                     cancelled = True
-                    for pending in futures:
-                        pending.cancel()
+                    for waiting in futures:
+                        waiting.cancel()
                 if future.cancelled():
                     continue
                 attempted += 1
@@ -376,7 +390,7 @@ class Downloader:
             expected=plan.expected,
             attempted=attempted,
             completed=completed,
-            skipped=0,
+            skipped=skipped,
             failed=tuple(failures),
             cancelled=cancelled,
             bytes_written=bytes_written,

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -27,6 +27,7 @@ from slugify import slugify
 from antenati import http, iiif, provenance
 from antenati import image as image_validation
 from antenati.errors import AntenatiError, ResourceLimitError, ThreadError
+from antenati.validation import DownloadOptions, validate_download_options, validate_page_range
 
 logger = logging.getLogger(__name__)
 
@@ -94,8 +95,6 @@ class DownloadReport:
 
 
 class _ByteBudget:
-    """Thread-safe total-transfer budget shared by image workers."""
-
     def __init__(self, limit: int):
         self._limit = limit
         self._used = 0
@@ -119,6 +118,11 @@ class Downloader:
         descriptive_names: bool = False,
         limits: DownloadLimits | None = None,
     ):
+        validate_page_range(first, last)
+        if not url.strip():
+            from antenati.errors import ValidationError
+
+            raise ValidationError('url must not be empty')
         self.url = url
         self.first = first
         self.last = last
@@ -204,9 +208,7 @@ class Downloader:
         manifest, manifest_url = self._load_manifest()
         all_canvases = iiif.slice_canvases(manifest, 0, None)
         if len(all_canvases) > self.limits.max_canvases:
-            raise ResourceLimitError(
-                f'Manifest contains {len(all_canvases)} canvases; limit is {self.limits.max_canvases}'
-            )
+            raise ResourceLimitError(f'Manifest contains {len(all_canvases)} canvases; limit is {self.limits.max_canvases}')
         canvases = iiif.slice_canvases(manifest, self.first, self.last)
         if archive_id is None:
             archive_id = iiif.get_archive_id_from_canvases(all_canvases)
@@ -221,6 +223,10 @@ class Downloader:
         return self
 
     def plan(self, size: int = DEFAULT_SIZE) -> DownloadPlan:
+        if size < 0:
+            from antenati.errors import ValidationError
+
+            raise ValidationError('size must be >= 0')
         self.load()
         if self._plan is not None and self._plan.size == size:
             return self._plan
@@ -336,7 +342,6 @@ class Downloader:
             filename = self.dirname / f'{item.stem}{extension}'
             digest = sha256()
             byte_size = 0
-
             with NamedTemporaryFile(
                 mode='wb',
                 dir=self.dirname,
@@ -352,15 +357,12 @@ class Downloader:
                         raise CancelledError
                     byte_size += len(chunk)
                     if byte_size > self.limits.max_image_bytes:
-                        raise ResourceLimitError(
-                            f'{item.source_url}: image exceeded {self.limits.max_image_bytes} byte limit'
-                        )
+                        raise ResourceLimitError(f'{item.source_url}: image exceeded {self.limits.max_image_bytes} byte limit')
                     budget.consume(len(chunk))
                     img_file.write(chunk)
                     digest.update(chunk)
                 img_file.flush()
                 os.fsync(img_file.fileno())
-
             image_validation.validate_image_file(content_type, Path(temp_name))
             if cancel is not None and cancel.is_set():
                 raise CancelledError
@@ -410,6 +412,7 @@ class Downloader:
         limit: int,
         submit: Callable[[DownloadItem], Future[provenance.ImageRecord]],
     ) -> None:
+        del executor
         while len(futures) < limit:
             try:
                 item = next(items)
@@ -427,12 +430,12 @@ class Downloader:
         *,
         resume: bool = False,
     ) -> DownloadReport:
+        validate_download_options(DownloadOptions(first=self.first, last=self.last, size=size, n_workers=n_workers))
         plan = self.plan(size)
         progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():
             logger.info('Download cancelled before any image work was submitted')
             return DownloadReport(plan.expected, 0, 0, 0, (), True, 0)
-
         verified = (
             provenance.verified_resume_records(self.dirname, manifest_url=self.manifest_url, requested_size=size) if resume else {}
         )
@@ -447,7 +450,6 @@ class Downloader:
                 records.append(existing)
                 skipped += 1
                 progress.update()
-
         attempted = 0
         completed = 0
         bytes_written = 0
@@ -457,8 +459,8 @@ class Downloader:
         item_iter = iter(pending)
         in_flight: dict[Future[provenance.ImageRecord], DownloadItem] = {}
         in_flight_limit = self._in_flight_limit(n_workers)
-
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
+
             def submit(item: DownloadItem) -> Future[provenance.ImageRecord]:
                 return executor.submit(self._thread_main, item, size, cancel, budget)
 
@@ -487,7 +489,6 @@ class Downloader:
                         records.append(record)
                 if not cancelled:
                     self._fill_futures(executor, item_iter, in_flight, in_flight_limit, submit)
-
         self._persist_provenance(size, records)
         return DownloadReport(
             expected=plan.expected,

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -301,7 +301,7 @@ class Downloader:
 
     def print_gallery_info(self) -> None:
         for entry in self.manifest['metadata']:
-            print(f"{entry['label']:<25}{entry['value']}")
+            print(f'{entry["label"]:<25}{entry["value"]}')
         print(f'{self.gallery_length} images found.')
 
     def check_dir(self, parentdir: str | None = None, interactive: bool = True) -> None:
@@ -436,9 +436,7 @@ class Downloader:
         if cancel is not None and cancel.is_set():
             logger.info('Download cancelled before any image work was submitted')
             return DownloadReport(plan.expected, 0, 0, 0, (), True, 0)
-        verified = (
-            provenance.verified_resume_records(self.dirname, manifest_url=self.manifest_url, requested_size=size) if resume else {}
-        )
+        verified = provenance.verified_resume_records(self.dirname, manifest_url=self.manifest_url, requested_size=size) if resume else {}
         records: list[provenance.ImageRecord] = []
         pending: list[DownloadItem] = []
         skipped = 0

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -437,7 +437,10 @@ class Downloader:
             logger.info('Download cancelled before any image work was submitted')
             return DownloadReport(plan.expected, 0, 0, 0, (), True, 0)
         verified = provenance.verified_resume_records(self.dirname, manifest_url=self.manifest_url, requested_size=size) if resume else {}
-        records: list[provenance.ImageRecord] = []
+        plan_keys = {self._resume_key(item) for item in plan.items}
+        records: list[provenance.ImageRecord] = provenance.carry_over_records(
+            self.dirname, manifest_url=self.manifest_url, requested_size=size, exclude_keys=plan_keys
+        )
         pending: list[DownloadItem] = []
         skipped = 0
         for item in plan.items:

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from collections.abc import Callable
-from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
+from collections.abc import Callable, Iterator
+from concurrent.futures import FIRST_COMPLETED, CancelledError, Future, ThreadPoolExecutor, wait
 from contextlib import suppress
 from dataclasses import dataclass
 from hashlib import sha256
@@ -21,17 +21,28 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 
 from click import confirm, echo
-from requests import RequestException, Session
+from requests import RequestException, Response, Session
 from slugify import slugify
 
 from antenati import http, iiif, provenance
 from antenati import image as image_validation
-from antenati.errors import AntenatiError, ThreadError
+from antenati.errors import AntenatiError, ResourceLimitError, ThreadError
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SIZE: int = 0
 DEFAULT_N_THREADS: int = 2
+
+
+@dataclass(frozen=True)
+class DownloadLimits:
+    """Resource ceilings used to keep malformed/huge sources bounded."""
+
+    max_canvases: int = 20_000
+    max_metadata_bytes: int = 20 * 1024 * 1024
+    max_image_bytes: int = 512 * 1024 * 1024
+    max_total_bytes: int = 20 * 1024 * 1024 * 1024
+    in_flight_factor: int = 2
 
 
 @dataclass
@@ -82,14 +93,37 @@ class DownloadReport:
         return max(0, self.expected - self.completed - self.skipped - len(self.failed))
 
 
+class _ByteBudget:
+    """Thread-safe total-transfer budget shared by image workers."""
+
+    def __init__(self, limit: int):
+        self._limit = limit
+        self._used = 0
+        self._lock = threading.Lock()
+
+    def consume(self, amount: int) -> None:
+        with self._lock:
+            if self._used + amount > self._limit:
+                raise ResourceLimitError(f'Total download budget exceeded ({self._limit} bytes)')
+            self._used += amount
+
+
 class Downloader:
     """Plan and execute a Portale Antenati gallery download."""
 
-    def __init__(self, url: str, first: int, last: int | None, descriptive_names: bool = False):
+    def __init__(
+        self,
+        url: str,
+        first: int,
+        last: int | None,
+        descriptive_names: bool = False,
+        limits: DownloadLimits | None = None,
+    ):
         self.url = url
         self.first = first
         self.last = last
         self.descriptive_names = descriptive_names
+        self.limits = limits or DownloadLimits()
         self.session: Session = http.build_session()
         self._manifest: dict[str, Any] | None = None
         self._manifest_url: str | None = None
@@ -144,6 +178,24 @@ class Downloader:
     def gallery_length(self) -> int:
         return len(self.canvases)
 
+    def _read_limited(self, response: Response, limit: int) -> bytes:
+        data = bytearray()
+        try:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                if len(data) + len(chunk) > limit:
+                    raise ResourceLimitError(f'Response exceeded metadata limit ({limit} bytes): {response.url}')
+                data.extend(chunk)
+        finally:
+            response.close()
+        return bytes(data)
+
+    def _fetch_text(self, url: str) -> str:
+        reply = http.fetch(self.session, url, stream=True)
+        charset = http.get_content_charset(reply) or 'utf-8'
+        return self._read_limited(reply, self.limits.max_metadata_bytes).decode(charset)
+
     def load(self) -> Downloader:
         if self._manifest is not None:
             return self
@@ -151,6 +203,10 @@ class Downloader:
         logger.info('Loading manifest from %s', self.url)
         manifest, manifest_url = self._load_manifest()
         all_canvases = iiif.slice_canvases(manifest, 0, None)
+        if len(all_canvases) > self.limits.max_canvases:
+            raise ResourceLimitError(
+                f'Manifest contains {len(all_canvases)} canvases; limit is {self.limits.max_canvases}'
+            )
         canvases = iiif.slice_canvases(manifest, self.first, self.last)
         if archive_id is None:
             archive_id = iiif.get_archive_id_from_canvases(all_canvases)
@@ -187,14 +243,10 @@ class Downloader:
         if iiif.is_manifest_url(self.url):
             manifest_url = self.url
         else:
-            gallery_reply = http.fetch(self.session, self.url)
-            gallery_charset = http.get_content_charset(gallery_reply) or 'utf-8'
-            gallery_html = gallery_reply.content.decode(gallery_charset)
+            gallery_html = self._fetch_text(self.url)
             manifest_url = iiif.parse_manifest_url_from_html(gallery_html, self.url)
         logger.debug('Manifest URL: %s', manifest_url)
-        manifest_reply = http.fetch(self.session, manifest_url)
-        manifest_charset = http.get_content_charset(manifest_reply) or 'utf-8'
-        return loads(manifest_reply.content.decode(manifest_charset)), manifest_url
+        return loads(self._fetch_text(manifest_url)), manifest_url
 
     def _resolve_ark_id(self, canvases: list[dict[str, Any]], archive_id: str) -> str:
         first_canvas_url = str(canvases[0].get('@id', ''))
@@ -265,19 +317,26 @@ class Downloader:
     def _resume_key(item: DownloadItem) -> tuple[str, str]:
         return str(item.canvas.get('@id', '')), item.source_url
 
-    def _thread_main(self, item: DownloadItem, size: int, cancel: threading.Event | None) -> provenance.ImageRecord:
+    def _thread_main(
+        self,
+        item: DownloadItem,
+        size: int,
+        cancel: threading.Event | None,
+        budget: _ByteBudget,
+    ) -> provenance.ImageRecord:
         label = slugify(str(item.canvas.get('label', ''))) or item.stem
         temp_name: str | None = None
+        reply: Response | None = None
         try:
             if cancel is not None and cancel.is_set():
                 raise CancelledError
-            http_reply = http.fetch(self.session, item.source_url)
-            if cancel is not None and cancel.is_set():
-                raise CancelledError
-            content_type = http.get_content_type(http_reply)
-            content = http_reply.content
-            extension = image_validation.validate_image_bytes(content_type, content)
+            reply = http.fetch(self.session, item.source_url, stream=True)
+            content_type = http.get_content_type(reply)
+            extension = image_validation.extension_for_media_type(content_type)
             filename = self.dirname / f'{item.stem}{extension}'
+            digest = sha256()
+            byte_size = 0
+
             with NamedTemporaryFile(
                 mode='wb',
                 dir=self.dirname,
@@ -286,9 +345,23 @@ class Downloader:
                 delete=False,
             ) as img_file:
                 temp_name = img_file.name
-                img_file.write(content)
+                for chunk in reply.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    if cancel is not None and cancel.is_set():
+                        raise CancelledError
+                    byte_size += len(chunk)
+                    if byte_size > self.limits.max_image_bytes:
+                        raise ResourceLimitError(
+                            f'{item.source_url}: image exceeded {self.limits.max_image_bytes} byte limit'
+                        )
+                    budget.consume(len(chunk))
+                    img_file.write(chunk)
+                    digest.update(chunk)
                 img_file.flush()
                 os.fsync(img_file.fileno())
+
+            image_validation.validate_image_file(content_type, Path(temp_name))
             if cancel is not None and cancel.is_set():
                 raise CancelledError
             os.replace(temp_name, filename)
@@ -299,15 +372,17 @@ class Downloader:
                 source_url=item.source_url,
                 filename=filename.name,
                 requested_size=size,
-                byte_size=len(content),
-                sha256=sha256(content).hexdigest(),
+                byte_size=byte_size,
+                sha256=digest.hexdigest(),
             )
         except CancelledError:
             raise
-        except (RequestException, AntenatiError, OSError, RuntimeError) as ex:
+        except (RequestException, AntenatiError, OSError, RuntimeError, ValueError) as ex:
             logger.warning('Image %s failed: %s', label, ex)
             raise ThreadError(label) from ex
         finally:
+            if reply is not None:
+                reply.close()
             if temp_name is not None:
                 with suppress(FileNotFoundError):
                     os.unlink(temp_name)
@@ -323,6 +398,25 @@ class Downloader:
             requested_size=size,
             records=sorted(records, key=lambda record: record.filename),
         )
+
+    def _in_flight_limit(self, n_workers: int) -> int:
+        return max(1, n_workers, n_workers * self.limits.in_flight_factor)
+
+    @staticmethod
+    def _fill_futures(
+        executor: ThreadPoolExecutor,
+        items: Iterator[DownloadItem],
+        futures: dict[Future[provenance.ImageRecord], DownloadItem],
+        limit: int,
+        submit: Callable[[DownloadItem], Future[provenance.ImageRecord]],
+    ) -> None:
+        while len(futures) < limit:
+            try:
+                item = next(items)
+            except StopIteration:
+                return
+            future = submit(item)
+            futures[future] = item
 
     def run(
         self,
@@ -359,28 +453,40 @@ class Downloader:
         bytes_written = 0
         failures: list[PageFailure] = []
         cancelled = False
+        budget = _ByteBudget(self.limits.max_total_bytes)
+        item_iter = iter(pending)
+        in_flight: dict[Future[provenance.ImageRecord], DownloadItem] = {}
+        in_flight_limit = self._in_flight_limit(n_workers)
 
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            futures = {executor.submit(self._thread_main, item, size, cancel) for item in pending}
-            for future in as_completed(futures):
-                if cancel is not None and cancel.is_set():
-                    cancelled = True
-                    for waiting in futures:
-                        waiting.cancel()
-                if future.cancelled():
-                    continue
-                attempted += 1
-                progress.update()
-                try:
-                    record = future.result()
-                except CancelledError:
-                    cancelled = True
-                except ThreadError as ex:
-                    failures.append(PageFailure(ex.label, str(ex.__cause__)))
-                else:
-                    completed += 1
-                    bytes_written += record.byte_size
-                    records.append(record)
+            def submit(item: DownloadItem) -> Future[provenance.ImageRecord]:
+                return executor.submit(self._thread_main, item, size, cancel, budget)
+
+            self._fill_futures(executor, item_iter, in_flight, in_flight_limit, submit)
+            while in_flight:
+                done, _ = wait(tuple(in_flight), return_when=FIRST_COMPLETED)
+                for future in done:
+                    in_flight.pop(future, None)
+                    if cancel is not None and cancel.is_set():
+                        cancelled = True
+                        for waiting in in_flight:
+                            waiting.cancel()
+                    if future.cancelled():
+                        continue
+                    attempted += 1
+                    progress.update()
+                    try:
+                        record = future.result()
+                    except CancelledError:
+                        cancelled = True
+                    except ThreadError as ex:
+                        failures.append(PageFailure(ex.label, str(ex.__cause__)))
+                    else:
+                        completed += 1
+                        bytes_written += record.byte_size
+                        records.append(record)
+                if not cancelled:
+                    self._fill_futures(executor, item_iter, in_flight, in_flight_limit, submit)
 
         self._persist_provenance(size, records)
         return DownloadReport(

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -13,7 +13,6 @@ from contextlib import suppress
 from dataclasses import dataclass
 from hashlib import sha256
 from json import loads
-from mimetypes import guess_extension
 from os import mkdir, path
 from pathlib import Path
 from re import finditer
@@ -26,6 +25,7 @@ from requests import RequestException, Session
 from slugify import slugify
 
 from antenati import http, iiif, provenance
+from antenati import image as image_validation
 from antenati.errors import AntenatiError, ThreadError
 
 logger = logging.getLogger(__name__)
@@ -275,11 +275,9 @@ class Downloader:
             if cancel is not None and cancel.is_set():
                 raise CancelledError
             content_type = http.get_content_type(http_reply)
-            extension = guess_extension(content_type)
-            if not extension:
-                raise RuntimeError(f'{item.source_url}: Unable to guess extension "{content_type}"')
-            filename = self.dirname / f'{item.stem}{extension}'
             content = http_reply.content
+            extension = image_validation.validate_image_bytes(content_type, content)
+            filename = self.dirname / f'{item.stem}{extension}'
             with NamedTemporaryFile(
                 mode='wb',
                 dir=self.dirname,
@@ -335,7 +333,6 @@ class Downloader:
         *,
         resume: bool = False,
     ) -> DownloadReport:
-        """Execute a plan, optionally reusing only hash-verified indexed files."""
         plan = self.plan(size)
         progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -1,12 +1,6 @@
 # SPDX-FileCopyrightText: 2018 Giovanni Cerretani
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Core download orchestration for the Portale Antenati.
-
-The downloader lifecycle is deliberately split into explicit phases:
-construct configuration, load the manifest, build a deterministic plan, then
-execute it. Execution returns a structured :class:`DownloadReport` shared by
-CLI and GUI callers.
-"""
+"""Core download orchestration for the Portale Antenati."""
 
 from __future__ import annotations
 
@@ -17,6 +11,7 @@ from collections.abc import Callable
 from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from dataclasses import dataclass
+from hashlib import sha256
 from json import loads
 from mimetypes import guess_extension
 from os import mkdir, path
@@ -30,7 +25,7 @@ from click import confirm, echo
 from requests import RequestException, Session
 from slugify import slugify
 
-from antenati import http, iiif
+from antenati import http, iiif, provenance
 from antenati.errors import AntenatiError, ThreadError
 
 logger = logging.getLogger(__name__)
@@ -41,16 +36,12 @@ DEFAULT_N_THREADS: int = 2
 
 @dataclass
 class ProgressBar:
-    """Callback pair used to drive a progress indicator."""
-
     set_total: Callable[[int], None]
     update: Callable[[], None]
 
 
 @dataclass(frozen=True)
 class DownloadItem:
-    """One planned canvas download, independent from execution order."""
-
     canvas: dict[str, Any]
     stem: str
     source_url: str
@@ -58,8 +49,6 @@ class DownloadItem:
 
 @dataclass(frozen=True)
 class DownloadPlan:
-    """Immutable execution plan produced from a loaded manifest."""
-
     items: tuple[DownloadItem, ...]
     size: int
 
@@ -70,16 +59,12 @@ class DownloadPlan:
 
 @dataclass(frozen=True)
 class PageFailure:
-    """Failure associated with one planned page."""
-
     label: str
     reason: str
 
 
 @dataclass(frozen=True)
 class DownloadReport:
-    """Complete outcome of one execution attempt."""
-
     expected: int
     attempted: int
     completed: int
@@ -106,7 +91,6 @@ class Downloader:
         self.last = last
         self.descriptive_names = descriptive_names
         self.session: Session = http.build_session()
-
         self._manifest: dict[str, Any] | None = None
         self._manifest_url: str | None = None
         self._all_canvases: list[dict[str, Any]] | None = None
@@ -234,7 +218,6 @@ class Downloader:
 
     @staticmethod
     def _pad_numeric_label(label: str, width: int) -> str:
-        """Pad the last numeric component while preserving label semantics."""
         matches = list(finditer(r'\d+', label))
         if not matches:
             return label
@@ -265,15 +248,11 @@ class Downloader:
         return result
 
     def print_gallery_info(self) -> None:
-        """Write the gallery's IIIF metadata to stdout."""
         for entry in self.manifest['metadata']:
-            label = entry['label']
-            value = entry['value']
-            print(f'{label:<25}{value}')
+            print(f"{entry['label']:<25}{entry['value']}")
         print(f'{self.gallery_length} images found.')
 
     def check_dir(self, parentdir: str | None = None, interactive: bool = True) -> None:
-        """Ensure the output directory exists, prompting the user on conflict."""
         current = self.dirname
         if parentdir is not None:
             self.dirname = Path(parentdir) / current
@@ -288,20 +267,21 @@ class Downloader:
         else:
             mkdir(self.dirname)
 
-    def _thread_main(self, item: DownloadItem, cancel: threading.Event | None) -> int:
+    def _thread_main(self, item: DownloadItem, size: int, cancel: threading.Event | None) -> provenance.ImageRecord:
         label = slugify(str(item.canvas.get('label', ''))) or item.stem
         temp_name: str | None = None
         try:
             if cancel is not None and cancel.is_set():
-                return 0
+                raise CancelledError
             http_reply = http.fetch(self.session, item.source_url)
             if cancel is not None and cancel.is_set():
-                return 0
+                raise CancelledError
             content_type = http.get_content_type(http_reply)
             extension = guess_extension(content_type)
             if not extension:
                 raise RuntimeError(f'{item.source_url}: Unable to guess extension "{content_type}"')
             filename = self.dirname / f'{item.stem}{extension}'
+            content = http_reply.content
 
             with NamedTemporaryFile(
                 mode='wb',
@@ -311,14 +291,24 @@ class Downloader:
                 delete=False,
             ) as img_file:
                 temp_name = img_file.name
-                img_file.write(http_reply.content)
+                img_file.write(content)
                 img_file.flush()
                 os.fsync(img_file.fileno())
             if cancel is not None and cancel.is_set():
-                return 0
+                raise CancelledError
             os.replace(temp_name, filename)
             temp_name = None
-            return len(http_reply.content)
+            return provenance.ImageRecord.create(
+                canvas_id=str(item.canvas.get('@id', '')),
+                label=str(item.canvas.get('label', '')),
+                source_url=item.source_url,
+                filename=filename.name,
+                requested_size=size,
+                byte_size=len(content),
+                sha256=sha256(content).hexdigest(),
+            )
+        except CancelledError:
+            raise
         except (RequestException, AntenatiError, OSError, RuntimeError) as ex:
             logger.warning('Image %s failed: %s', label, ex)
             raise ThreadError(label) from ex
@@ -327,6 +317,18 @@ class Downloader:
                 with suppress(FileNotFoundError):
                     os.unlink(temp_name)
 
+    def _persist_provenance(self, size: int, records: list[provenance.ImageRecord]) -> None:
+        provenance.write_provenance(
+            self.dirname,
+            source_url=self.url,
+            manifest_url=self.manifest_url,
+            manifest=self.manifest,
+            archive_id=self.archive_id,
+            ark_id=self.ark_id,
+            requested_size=size,
+            records=sorted(records, key=lambda record: record.filename),
+        )
+
     def run(
         self,
         n_workers: int,
@@ -334,7 +336,6 @@ class Downloader:
         progress: ProgressBar,
         cancel: threading.Event | None = None,
     ) -> DownloadReport:
-        """Execute the selected plan and return a structured outcome report."""
         plan = self.plan(size)
         progress.set_total(plan.expected)
         if cancel is not None and cancel.is_set():
@@ -345,10 +346,11 @@ class Downloader:
         completed = 0
         bytes_written = 0
         failures: list[PageFailure] = []
+        records: list[provenance.ImageRecord] = []
         cancelled = False
 
         with ThreadPoolExecutor(max_workers=n_workers) as executor:
-            futures = {executor.submit(self._thread_main, item, cancel) for item in plan.items}
+            futures = {executor.submit(self._thread_main, item, size, cancel) for item in plan.items}
             for future in as_completed(futures):
                 if cancel is not None and cancel.is_set():
                     cancelled = True
@@ -359,18 +361,17 @@ class Downloader:
                 attempted += 1
                 progress.update()
                 try:
-                    written = future.result()
+                    record = future.result()
                 except CancelledError:
                     cancelled = True
                 except ThreadError as ex:
                     failures.append(PageFailure(ex.label, str(ex.__cause__)))
                 else:
-                    if written > 0:
-                        completed += 1
-                        bytes_written += written
-                    elif cancel is not None and cancel.is_set():
-                        cancelled = True
+                    completed += 1
+                    bytes_written += record.byte_size
+                    records.append(record)
 
+        self._persist_provenance(size, records)
         return DownloadReport(
             expected=plan.expected,
             attempted=attempted,

--- a/src/antenati/downloader.py
+++ b/src/antenati/downloader.py
@@ -106,6 +106,10 @@ class _ByteBudget:
                 raise ResourceLimitError(f'Total download budget exceeded ({self._limit} bytes)')
             self._used += amount
 
+    def release(self, amount: int) -> None:
+        with self._lock:
+            self._used = max(0, self._used - amount)
+
 
 class Downloader:
     """Plan and execute a Portale Antenati gallery download."""
@@ -333,6 +337,7 @@ class Downloader:
         label = slugify(str(item.canvas.get('label', ''))) or item.stem
         temp_name: str | None = None
         reply: Response | None = None
+        consumed = 0
         try:
             if cancel is not None and cancel.is_set():
                 raise CancelledError
@@ -359,6 +364,7 @@ class Downloader:
                     if byte_size > self.limits.max_image_bytes:
                         raise ResourceLimitError(f'{item.source_url}: image exceeded {self.limits.max_image_bytes} byte limit')
                     budget.consume(len(chunk))
+                    consumed += len(chunk)
                     img_file.write(chunk)
                     digest.update(chunk)
                 img_file.flush()
@@ -378,8 +384,10 @@ class Downloader:
                 sha256=digest.hexdigest(),
             )
         except CancelledError:
+            budget.release(consumed)
             raise
         except (RequestException, AntenatiError, OSError, RuntimeError, ValueError) as ex:
+            budget.release(consumed)
             logger.warning('Image %s failed: %s', label, ex)
             raise ThreadError(label) from ex
         finally:

--- a/src/antenati/errors.py
+++ b/src/antenati/errors.py
@@ -17,6 +17,10 @@ class ImageValidationError(AntenatiError):
     """A downloaded response is not a supported, internally consistent image."""
 
 
+class ResourceLimitError(AntenatiError):
+    """A configured safety limit was exceeded."""
+
+
 class WafChallengeError(AntenatiError):
     """The SAN server returned an AWS WAF challenge response that cannot be bypassed."""
 

--- a/src/antenati/errors.py
+++ b/src/antenati/errors.py
@@ -1,13 +1,6 @@
 # SPDX-FileCopyrightText: 2018 Giovanni Cerretani
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Exception hierarchy for the antenati downloader.
-
-A single base ``AntenatiError`` lets callers catch any tool-specific
-error with one ``except`` while still allowing fine-grained handling.
-``ManifestError`` is raised by :mod:`antenati.iiif` for malformed gallery
-or manifest data; ``WafChallengeError`` is raised by :mod:`antenati.http`
-on the SAN server's AWS WAF challenge response.
-"""
+"""Exception hierarchy for the antenati downloader."""
 
 from __future__ import annotations
 
@@ -20,16 +13,16 @@ class ManifestError(AntenatiError):
     """The IIIF manifest is missing a required field or has an unexpected shape."""
 
 
+class ImageValidationError(AntenatiError):
+    """A downloaded response is not a supported, internally consistent image."""
+
+
 class WafChallengeError(AntenatiError):
     """The SAN server returned an AWS WAF challenge response that cannot be bypassed."""
 
 
 class ThreadError(AntenatiError):
-    """Container used inside the download thread pool for exception chaining.
-
-    Wraps the original exception so the orchestrator can associate the
-    failure with a specific canvas label without losing the cause.
-    """
+    """Associate a worker failure with a specific canvas label."""
 
     def __init__(self, label: str):
         super().__init__(label)

--- a/src/antenati/errors.py
+++ b/src/antenati/errors.py
@@ -9,12 +9,20 @@ class AntenatiError(Exception):
     """Base class for all antenati-specific errors."""
 
 
+class ValidationError(AntenatiError):
+    """User-supplied download options are invalid."""
+
+
 class ManifestError(AntenatiError):
     """The IIIF manifest is missing a required field or has an unexpected shape."""
 
 
 class ImageValidationError(AntenatiError):
     """A downloaded response is not a supported, internally consistent image."""
+
+
+class HttpMetadataError(AntenatiError):
+    """An HTTP response is missing required metadata."""
 
 
 class ResourceLimitError(AntenatiError):

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -18,7 +18,15 @@ from humanize import naturalsize
 from antenati import __contact__, __copyright__, __version__
 from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE
 from antenati.gui.progress import TkProgress
-from antenati.gui.worker import Cancelled, Done, DownloadParams, DownloadWorker, Failed, Progress, Tick
+from antenati.gui.worker import (
+    Cancelled,
+    Done,
+    DownloadParams,
+    DownloadWorker,
+    Failed,
+    Progress,
+    Tick,
+)
 from antenati.output import ExistingPolicy
 
 logger = logging.getLogger(__name__)
@@ -55,7 +63,10 @@ class App:
 
     def _build_menu(self) -> None:
         menu_file = tk.Menu(self._menu, tearoff=0)
-        menu_file.add_command(label='Portale Antenati Website', command=lambda: webopen('https://antenati.cultura.gov.it/'))
+        menu_file.add_command(
+            label='Portale Antenati Website',
+            command=lambda: webopen('https://antenati.cultura.gov.it/'),
+        )
         menu_file.add_command(label='Project Website', command=lambda: webopen(__contact__))
         menu_file.add_separator()
         menu_file.add_command(label='About', command=self._show_about)
@@ -65,30 +76,98 @@ class App:
         entry_frame = ttk.Frame(self._root)
         entry_frame.pack(side=tk.TOP, fill=tk.X)
 
-        tk.Label(entry_frame, text='Archive or manifest URL').grid(row=0, column=0, padx=10, pady=5, sticky=tk.W)
-        ttk.Entry(entry_frame, textvariable=self._url, width=100).grid(row=0, column=1, padx=10, pady=5, columnspan=3, sticky=tk.EW)
+        tk.Label(entry_frame, text='Archive or manifest URL').grid(
+            row=0,
+            column=0,
+            padx=10,
+            pady=5,
+            sticky=tk.W,
+        )
+        ttk.Entry(entry_frame, textvariable=self._url, width=100).grid(
+            row=0,
+            column=1,
+            padx=10,
+            pady=5,
+            columnspan=3,
+            sticky=tk.EW,
+        )
 
         options = ttk.LabelFrame(entry_frame, text='Options')
         options.grid(row=1, column=0, columnspan=4, padx=10, pady=5, sticky=tk.EW)
 
         tk.Label(options, text='Size (px):').grid(row=0, column=0, sticky=tk.W, padx=6, pady=2)
-        ttk.Spinbox(options, textvariable=self._size, width=10, from_=0, to=5000, increment=100).grid(row=0, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='Maximum image size in pixels (0 = full size)').grid(row=0, column=2, sticky=tk.W, padx=6, pady=2)
+        ttk.Spinbox(
+            options,
+            textvariable=self._size,
+            width=10,
+            from_=0,
+            to=5000,
+            increment=100,
+        ).grid(row=0, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='Maximum image size in pixels (0 = full size)').grid(
+            row=0,
+            column=2,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
 
         tk.Label(options, text='First:').grid(row=1, column=0, sticky=tk.W, padx=6, pady=2)
-        ttk.Spinbox(options, textvariable=self._first, width=10, from_=0, to=100000, increment=1).grid(row=1, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='Index (0-based) of the first image to download').grid(row=1, column=2, sticky=tk.W, padx=6, pady=2)
+        ttk.Spinbox(
+            options,
+            textvariable=self._first,
+            width=10,
+            from_=0,
+            to=100000,
+            increment=1,
+        ).grid(row=1, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='Index (0-based) of the first image to download').grid(
+            row=1,
+            column=2,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
 
         tk.Label(options, text='Last (exclusive):').grid(row=2, column=0, sticky=tk.W, padx=6, pady=2)
-        ttk.Entry(options, textvariable=self._last, width=10).grid(row=2, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='Index NOT to download; leave empty to download all').grid(row=2, column=2, sticky=tk.W, padx=6, pady=2)
+        ttk.Entry(options, textvariable=self._last, width=10).grid(
+            row=2,
+            column=1,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
+        tk.Label(options, text='Index NOT to download; leave empty to download all').grid(
+            row=2,
+            column=2,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
 
         tk.Label(options, text='Threads:').grid(row=3, column=0, sticky=tk.W, padx=6, pady=2)
-        ttk.Spinbox(options, textvariable=self._n_workers, width=10, from_=1, to=64, increment=1).grid(row=3, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='Maximum concurrent image workers').grid(row=3, column=2, sticky=tk.W, padx=6, pady=2)
+        ttk.Spinbox(
+            options,
+            textvariable=self._n_workers,
+            width=10,
+            from_=1,
+            to=64,
+            increment=1,
+        ).grid(row=3, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='Maximum concurrent image workers').grid(
+            row=3,
+            column=2,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
 
         tk.Label(options, text='Filenames:').grid(row=4, column=0, sticky=tk.W, padx=6, pady=2)
-        ttk.Checkbutton(options, text='Include archive/image IDs', variable=self._descriptive).grid(row=4, column=1, columnspan=2, sticky=tk.W, padx=6, pady=2)
+        ttk.Checkbutton(
+            options,
+            text='Include archive/image IDs',
+            variable=self._descriptive,
+        ).grid(row=4, column=1, columnspan=2, sticky=tk.W, padx=6, pady=2)
 
         tk.Label(options, text='Existing files:').grid(row=5, column=0, sticky=tk.W, padx=6, pady=2)
         ttk.Combobox(
@@ -98,17 +177,51 @@ class App:
             state='readonly',
             width=12,
         ).grid(row=5, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='ask (default), error, overwrite, skip, or verified resume').grid(row=5, column=2, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='ask (default), error, overwrite, skip, or verified resume').grid(
+            row=5,
+            column=2,
+            sticky=tk.W,
+            padx=6,
+            pady=2,
+        )
 
-        tk.Label(entry_frame, text='Output directory').grid(row=2, column=0, padx=10, pady=5, sticky=tk.EW)
-        ttk.Entry(entry_frame, textvariable=self._path, width=100).grid(row=2, column=1, padx=10, pady=5, columnspan=2, sticky=tk.EW)
-        ttk.Button(entry_frame, text='Browse', command=self._browse_path).grid(row=2, column=3, padx=10, pady=5, sticky=tk.EW)
+        tk.Label(entry_frame, text='Output directory').grid(
+            row=2,
+            column=0,
+            padx=10,
+            pady=5,
+            sticky=tk.EW,
+        )
+        ttk.Entry(entry_frame, textvariable=self._path, width=100).grid(
+            row=2,
+            column=1,
+            padx=10,
+            pady=5,
+            columnspan=2,
+            sticky=tk.EW,
+        )
+        ttk.Button(entry_frame, text='Browse', command=self._browse_path).grid(
+            row=2,
+            column=3,
+            padx=10,
+            pady=5,
+            sticky=tk.EW,
+        )
 
         self._download_button = ttk.Button(entry_frame, text='Download', command=self._on_download)
         self._download_button.grid(row=3, column=1, padx=5, pady=5)
-        self._cancel_button = ttk.Button(entry_frame, text='Cancel', command=self._on_cancel, state=tk.DISABLED)
+        self._cancel_button = ttk.Button(
+            entry_frame,
+            text='Cancel',
+            command=self._on_cancel,
+            state=tk.DISABLED,
+        )
         self._cancel_button.grid(row=3, column=2, padx=5, pady=5)
-        ttk.Button(entry_frame, text='Support this project', command=lambda: webopen('https://ko-fi.com/gcerretani')).grid(row=3, column=3, padx=5, pady=5)
+        ttk.Button(
+            entry_frame,
+            text='Support this project',
+            command=lambda: webopen('https://ko-fi.com/gcerretani'),
+        ).grid(row=3, column=3, padx=5, pady=5)
 
     def _build_footer(self) -> None:
         footer_frame = ttk.Frame(self._root)
@@ -219,14 +332,23 @@ class App:
             self._set_running(False)
             report = event.report
             if report.successful:
-                tkmsg.showinfo('Success', f'Completed {report.completed}, skipped {report.skipped}. New data: {naturalsize(report.bytes_written, True)}')
+                tkmsg.showinfo(
+                    'Success',
+                    f'Completed {report.completed}, skipped {report.skipped}. New data: {naturalsize(report.bytes_written, True)}',
+                )
             else:
                 details = '\n'.join(f'{f.label}: {f.reason}' for f in report.failed)
-                tkmsg.showwarning('Incomplete download', f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}')
+                tkmsg.showwarning(
+                    'Incomplete download',
+                    f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}',
+                )
         elif isinstance(event, Cancelled):
             self._terminal_received = True
             self._set_running(False)
-            tkmsg.showinfo('Cancelled', f'Download cancelled after {event.report.completed}/{event.report.expected} pages.')
+            tkmsg.showinfo(
+                'Cancelled',
+                f'Download cancelled after {event.report.completed}/{event.report.expected} pages.',
+            )
         elif isinstance(event, Failed):
             self._terminal_received = True
             self._set_running(False)

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -10,6 +10,7 @@ import tkinter as tk
 import tkinter.filedialog as tkfile
 import tkinter.messagebox as tkmsg
 import tkinter.ttk as ttk
+from pathlib import Path
 from webbrowser import open as webopen
 
 from humanize import naturalsize
@@ -40,7 +41,7 @@ class App:
         self._n_workers = tk.IntVar(value=DEFAULT_N_THREADS)
         self._descriptive = tk.BooleanVar(value=False)
         self._path = tk.StringVar()
-        self._existing = tk.StringVar(value=ExistingPolicy.ERROR.value)
+        self._existing = tk.StringVar(value=ExistingPolicy.ASK.value)
 
         self._menu = tk.Menu(self._root)
         self._root.configure(menu=self._menu)
@@ -97,7 +98,7 @@ class App:
             state='readonly',
             width=12,
         ).grid(row=5, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='error (safe default), overwrite, skip, or verified resume').grid(row=5, column=2, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='ask (default), error, overwrite, skip, or verified resume').grid(row=5, column=2, sticky=tk.W, padx=6, pady=2)
 
         tk.Label(entry_frame, text='Output directory').grid(row=2, column=0, padx=10, pady=5, sticky=tk.EW)
         ttk.Entry(entry_frame, textvariable=self._path, width=100).grid(row=2, column=1, padx=10, pady=5, columnspan=2, sticky=tk.EW)
@@ -129,6 +130,37 @@ class App:
         if selected_path:
             self._path.set(selected_path)
 
+    def _resolve_gui_policy(self, output: str, policy: ExistingPolicy) -> ExistingPolicy | None:
+        """Resolve ``ask`` on the Tk thread; the background worker stays non-interactive."""
+        if policy is not ExistingPolicy.ASK:
+            return policy
+        directory = Path(output)
+        if not directory.exists() or not directory.is_dir() or not any(directory.iterdir()):
+            return ExistingPolicy.ERROR
+
+        resume = tkmsg.askyesnocancel(
+            'Existing output',
+            'The destination already contains files.\n\n'
+            'Yes: resume and verify existing downloads (recommended)\n'
+            'No: choose another action\n'
+            'Cancel: stop',
+        )
+        if resume is None:
+            return None
+        if resume:
+            return ExistingPolicy.RESUME
+
+        overwrite = tkmsg.askyesnocancel(
+            'Existing output',
+            'Overwrite planned files?\n\n'
+            'Yes: overwrite\n'
+            'No: skip verified files and refuse ambiguous files\n'
+            'Cancel: stop',
+        )
+        if overwrite is None:
+            return None
+        return ExistingPolicy.OVERWRITE if overwrite else ExistingPolicy.SKIP
+
     def _on_download(self) -> None:
         url = self._url.get().strip()
         if not url:
@@ -136,6 +168,10 @@ class App:
         output_value = self._path.get().strip()
         if not output_value:
             raise RuntimeError('Please choose an output directory.')
+
+        policy = self._resolve_gui_policy(output_value, ExistingPolicy(self._existing.get()))
+        if policy is None:
+            return
 
         last_raw = self._last.get().strip()
         last_val = int(last_raw) if last_raw else None
@@ -147,7 +183,7 @@ class App:
             last=last_val,
             n_workers=int(self._n_workers.get()),
             descriptive_names=bool(self._descriptive.get()),
-            existing_policy=ExistingPolicy(self._existing.get()),
+            existing_policy=policy,
         )
 
         self._progress = TkProgress(self._progress_bar)

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -118,7 +118,6 @@ class App:
 
         last_raw = self._last.get().strip()
         last_val = int(last_raw) if last_raw else None
-
         params = DownloadParams(url=url, parent_dir=path_value, size=self._size.get(), first=int(self._first.get()), last=last_val)
 
         self._progress = TkProgress(self._progress_bar)
@@ -139,10 +138,6 @@ class App:
                 self._handle_event(event)
         except queue.Empty:
             pass
-        # Do not use worker liveness as the completion signal.  The worker can
-        # enqueue Done/Failed and exit between the empty-queue check and the
-        # liveness check; polling until the terminal event is consumed closes
-        # that race.
         if not self._terminal_received:
             self._root.after(_POLL_INTERVAL_MS, self._drain_events)
 
@@ -156,11 +151,19 @@ class App:
         elif isinstance(event, Done):
             self._terminal_received = True
             self._set_running(False)
-            tkmsg.showinfo('Success', f'Operation completed successfully. Total size: {naturalsize(event.total_bytes, True)}')
+            report = event.report
+            if report.successful:
+                tkmsg.showinfo('Success', f'Operation completed successfully. Total size: {naturalsize(report.bytes_written, True)}')
+            else:
+                details = '\n'.join(f'{f.label}: {f.reason}' for f in report.failed)
+                tkmsg.showwarning(
+                    'Incomplete download',
+                    f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}',
+                )
         elif isinstance(event, Cancelled):
             self._terminal_received = True
             self._set_running(False)
-            tkmsg.showinfo('Cancelled', 'Download cancelled.')
+            tkmsg.showinfo('Cancelled', f'Download cancelled after {event.report.completed}/{event.report.expected} pages.')
         elif isinstance(event, Failed):
             self._terminal_received = True
             self._set_running(False)
@@ -176,7 +179,6 @@ class App:
 
 
 def main() -> None:
-    """Launch the Tkinter GUI."""
     tk_root = tk.Tk()
 
     def _callback_exception(_type, ex: BaseException, _traceback):

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -18,6 +18,7 @@ from antenati import __contact__, __copyright__, __version__
 from antenati.downloader import DEFAULT_SIZE
 from antenati.gui.progress import TkProgress
 from antenati.gui.worker import Cancelled, Done, DownloadParams, DownloadWorker, Failed, Progress, Tick
+from antenati.output import ExistingPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class App:
         self._first = tk.IntVar(value=0)
         self._last = tk.StringVar(value='')
         self._path = tk.StringVar()
+        self._existing = tk.StringVar(value=ExistingPolicy.ERROR.value)
 
         self._menu = tk.Menu(self._root)
         self._root.configure(menu=self._menu)
@@ -78,7 +80,17 @@ class App:
         ttk.Entry(options, textvariable=self._last, width=10).grid(row=2, column=1, sticky=tk.W, padx=6, pady=2)
         tk.Label(options, text='Index NOT to download; leave empty to download all').grid(row=2, column=2, sticky=tk.W, padx=6, pady=2)
 
-        tk.Label(entry_frame, text='Destination folder').grid(row=2, column=0, padx=10, pady=5, sticky=tk.EW)
+        tk.Label(options, text='Existing files:').grid(row=3, column=0, sticky=tk.W, padx=6, pady=2)
+        ttk.Combobox(
+            options,
+            textvariable=self._existing,
+            values=[policy.value for policy in ExistingPolicy],
+            state='readonly',
+            width=12,
+        ).grid(row=3, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='error (safe default), overwrite, skip, or verified resume').grid(row=3, column=2, sticky=tk.W, padx=6, pady=2)
+
+        tk.Label(entry_frame, text='Output directory').grid(row=2, column=0, padx=10, pady=5, sticky=tk.EW)
         ttk.Entry(entry_frame, textvariable=self._path, width=100).grid(row=2, column=1, padx=10, pady=5, columnspan=2, sticky=tk.EW)
         ttk.Button(entry_frame, text='Browse', command=self._browse_path).grid(row=2, column=3, padx=10, pady=5, sticky=tk.EW)
 
@@ -112,13 +124,20 @@ class App:
         url = self._url.get().strip()
         if not url:
             raise RuntimeError('Please enter a valid URL.')
-        path_value = self._path.get().strip()
-        if not path_value:
-            raise RuntimeError('Please enter a valid destination folder.')
+        output_value = self._path.get().strip()
+        if not output_value:
+            raise RuntimeError('Please choose an output directory.')
 
         last_raw = self._last.get().strip()
         last_val = int(last_raw) if last_raw else None
-        params = DownloadParams(url=url, parent_dir=path_value, size=self._size.get(), first=int(self._first.get()), last=last_val)
+        params = DownloadParams(
+            url=url,
+            output_dir=output_value,
+            size=self._size.get(),
+            first=int(self._first.get()),
+            last=last_val,
+            existing_policy=ExistingPolicy(self._existing.get()),
+        )
 
         self._progress = TkProgress(self._progress_bar)
         self._terminal_received = False
@@ -153,13 +172,13 @@ class App:
             self._set_running(False)
             report = event.report
             if report.successful:
-                tkmsg.showinfo('Success', f'Operation completed successfully. Total size: {naturalsize(report.bytes_written, True)}')
+                tkmsg.showinfo(
+                    'Success',
+                    f'Completed {report.completed}, skipped {report.skipped}. New data: {naturalsize(report.bytes_written, True)}',
+                )
             else:
                 details = '\n'.join(f'{f.label}: {f.reason}' for f in report.failed)
-                tkmsg.showwarning(
-                    'Incomplete download',
-                    f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}',
-                )
+                tkmsg.showwarning('Incomplete download', f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}')
         elif isinstance(event, Cancelled):
             self._terminal_received = True
             self._set_running(False)

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -253,10 +253,7 @@ class App:
 
         resume = tkmsg.askyesnocancel(
             'Existing output',
-            'The destination already contains files.\n\n'
-            'Yes: resume and verify existing downloads (recommended)\n'
-            'No: choose another action\n'
-            'Cancel: stop',
+            'The destination already contains files.\n\nYes: resume and verify existing downloads (recommended)\nNo: choose another action\nCancel: stop',
         )
         if resume is None:
             return None
@@ -265,10 +262,7 @@ class App:
 
         overwrite = tkmsg.askyesnocancel(
             'Existing output',
-            'Overwrite planned files?\n\n'
-            'Yes: overwrite\n'
-            'No: skip verified files and refuse ambiguous files\n'
-            'Cancel: stop',
+            'Overwrite planned files?\n\nYes: overwrite\nNo: skip verified files and refuse ambiguous files\nCancel: stop',
         )
         if overwrite is None:
             return None

--- a/src/antenati/gui/app.py
+++ b/src/antenati/gui/app.py
@@ -15,7 +15,7 @@ from webbrowser import open as webopen
 from humanize import naturalsize
 
 from antenati import __contact__, __copyright__, __version__
-from antenati.downloader import DEFAULT_SIZE
+from antenati.downloader import DEFAULT_N_THREADS, DEFAULT_SIZE
 from antenati.gui.progress import TkProgress
 from antenati.gui.worker import Cancelled, Done, DownloadParams, DownloadWorker, Failed, Progress, Tick
 from antenati.output import ExistingPolicy
@@ -26,7 +26,7 @@ _POLL_INTERVAL_MS = 100
 
 
 class App:
-    """Top-level Tk window. Owns the worker, the progress bar and the layout."""
+    """Top-level Tk window. Owns the worker, progress bar and shared options."""
 
     def __init__(self, root: tk.Tk, title: str) -> None:
         self._root = root
@@ -37,6 +37,8 @@ class App:
         self._size = tk.IntVar(value=DEFAULT_SIZE)
         self._first = tk.IntVar(value=0)
         self._last = tk.StringVar(value='')
+        self._n_workers = tk.IntVar(value=DEFAULT_N_THREADS)
+        self._descriptive = tk.BooleanVar(value=False)
         self._path = tk.StringVar()
         self._existing = tk.StringVar(value=ExistingPolicy.ERROR.value)
 
@@ -80,15 +82,22 @@ class App:
         ttk.Entry(options, textvariable=self._last, width=10).grid(row=2, column=1, sticky=tk.W, padx=6, pady=2)
         tk.Label(options, text='Index NOT to download; leave empty to download all').grid(row=2, column=2, sticky=tk.W, padx=6, pady=2)
 
-        tk.Label(options, text='Existing files:').grid(row=3, column=0, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='Threads:').grid(row=3, column=0, sticky=tk.W, padx=6, pady=2)
+        ttk.Spinbox(options, textvariable=self._n_workers, width=10, from_=1, to=64, increment=1).grid(row=3, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='Maximum concurrent image workers').grid(row=3, column=2, sticky=tk.W, padx=6, pady=2)
+
+        tk.Label(options, text='Filenames:').grid(row=4, column=0, sticky=tk.W, padx=6, pady=2)
+        ttk.Checkbutton(options, text='Include archive/image IDs', variable=self._descriptive).grid(row=4, column=1, columnspan=2, sticky=tk.W, padx=6, pady=2)
+
+        tk.Label(options, text='Existing files:').grid(row=5, column=0, sticky=tk.W, padx=6, pady=2)
         ttk.Combobox(
             options,
             textvariable=self._existing,
             values=[policy.value for policy in ExistingPolicy],
             state='readonly',
             width=12,
-        ).grid(row=3, column=1, sticky=tk.W, padx=6, pady=2)
-        tk.Label(options, text='error (safe default), overwrite, skip, or verified resume').grid(row=3, column=2, sticky=tk.W, padx=6, pady=2)
+        ).grid(row=5, column=1, sticky=tk.W, padx=6, pady=2)
+        tk.Label(options, text='error (safe default), overwrite, skip, or verified resume').grid(row=5, column=2, sticky=tk.W, padx=6, pady=2)
 
         tk.Label(entry_frame, text='Output directory').grid(row=2, column=0, padx=10, pady=5, sticky=tk.EW)
         ttk.Entry(entry_frame, textvariable=self._path, width=100).grid(row=2, column=1, padx=10, pady=5, columnspan=2, sticky=tk.EW)
@@ -136,6 +145,8 @@ class App:
             size=self._size.get(),
             first=int(self._first.get()),
             last=last_val,
+            n_workers=int(self._n_workers.get()),
+            descriptive_names=bool(self._descriptive.get()),
             existing_policy=ExistingPolicy(self._existing.get()),
         )
 
@@ -172,10 +183,7 @@ class App:
             self._set_running(False)
             report = event.report
             if report.successful:
-                tkmsg.showinfo(
-                    'Success',
-                    f'Completed {report.completed}, skipped {report.skipped}. New data: {naturalsize(report.bytes_written, True)}',
-                )
+                tkmsg.showinfo('Success', f'Completed {report.completed}, skipped {report.skipped}. New data: {naturalsize(report.bytes_written, True)}')
             else:
                 details = '\n'.join(f'{f.label}: {f.reason}' for f in report.failed)
                 tkmsg.showwarning('Incomplete download', f'Completed {report.completed}/{report.expected}; failed {len(report.failed)}.\n{details}')

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -12,7 +12,8 @@ from typing import Protocol
 
 from antenati.config import DownloadConfig
 from antenati.downloader import Downloader, DownloadReport, ProgressBar
-from antenati.output import prepare_output, run_with_policy
+from antenati.gui.worker import *
+from antenati.output import ExistingPolicy, prepare_output, run_with_policy
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,8 @@ class DownloadWorker:
 
     def start(self, params: DownloadParams) -> None:
         params.validate(require_output=True)
+        if params.existing_policy is ExistingPolicy.ASK:
+            raise RuntimeError('ExistingPolicy.ASK must be resolved by the GUI before starting the worker')
         if self._thread is not None and self._thread.is_alive():
             raise RuntimeError('A download is already in progress')
         self._cancel.clear()

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from antenati.config import DownloadConfig
-from antenati.downloader import DownloadReport, Downloader, ProgressBar
+from antenati.downloader import Downloader, DownloadReport, ProgressBar
 from antenati.output import prepare_output, run_with_policy
 
 logger = logging.getLogger(__name__)

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from antenati.downloader import DEFAULT_N_THREADS, DownloadReport, Downloader, ProgressBar
+from antenati.output import ExistingPolicy, prepare_output, run_with_policy
 from antenati.validation import DownloadOptions
 
 logger = logging.getLogger(__name__)
@@ -47,11 +48,13 @@ WorkerEvent = Progress | Tick | Done | Cancelled | Failed
 @dataclass
 class DownloadParams:
     url: str
-    parent_dir: str
+    output_dir: str
     size: int
     first: int
     last: int | None
     n_workers: int = DEFAULT_N_THREADS
+    existing_policy: ExistingPolicy = ExistingPolicy.ERROR
+    descriptive_names: bool = False
 
     def options(self) -> DownloadOptions:
         return DownloadOptions(first=self.first, last=self.last, size=self.size, n_workers=self.n_workers)
@@ -62,19 +65,19 @@ class DownloadParams:
             from antenati.errors import ValidationError
 
             raise ValidationError('url must not be empty')
-        if not self.parent_dir.strip():
+        if not self.output_dir.strip():
             from antenati.errors import ValidationError
 
-            raise ValidationError('destination folder must not be empty')
+            raise ValidationError('output directory must not be empty')
         return self
 
 
 class DownloaderFactory(Protocol):
-    def __call__(self, url: str, first: int, last: int | None) -> Downloader: ...
+    def __call__(self, url: str, first: int, last: int | None, descriptive_names: bool = False) -> Downloader: ...
 
 
-def _default_factory(url: str, first: int, last: int | None) -> Downloader:
-    return Downloader(url, first, last)
+def _default_factory(url: str, first: int, last: int | None, descriptive_names: bool = False) -> Downloader:
+    return Downloader(url, first, last, descriptive_names=descriptive_names)
 
 
 class DownloadWorker:
@@ -105,14 +108,21 @@ class DownloadWorker:
     def _run(self, params: DownloadParams) -> None:
         try:
             params.validate()
-            downloader = self._factory(params.url, params.first, params.last)
+            downloader = self._factory(params.url, params.first, params.last, params.descriptive_names)
             downloader.load()
-            downloader.check_dir(params.parent_dir, interactive=False)
+            prepare_output(downloader, params.output_dir, params.existing_policy)
             progress = ProgressBar(
                 set_total=lambda total: self.events.put(Progress(total=total)),
                 update=lambda: self.events.put(Tick()),
             )
-            report = downloader.run(params.n_workers, params.size, progress, cancel=self._cancel)
+            report = run_with_policy(
+                downloader,
+                n_workers=params.n_workers,
+                size=params.size,
+                progress=progress,
+                policy=params.existing_policy,
+                cancel=self._cancel,
+            )
         except Exception as ex:
             logger.exception('Download worker failed')
             self.events.put(Failed(message=str(ex)))

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -10,9 +10,9 @@ import threading
 from dataclasses import dataclass
 from typing import Protocol
 
-from antenati.downloader import DEFAULT_N_THREADS, DownloadReport, Downloader, ProgressBar
-from antenati.output import ExistingPolicy, prepare_output, run_with_policy
-from antenati.validation import DownloadOptions
+from antenati.config import DownloadConfig
+from antenati.downloader import DownloadReport, Downloader, ProgressBar
+from antenati.output import prepare_output, run_with_policy
 
 logger = logging.getLogger(__name__)
 
@@ -46,30 +46,8 @@ WorkerEvent = Progress | Tick | Done | Cancelled | Failed
 
 
 @dataclass
-class DownloadParams:
-    url: str
-    output_dir: str
-    size: int
-    first: int
-    last: int | None
-    n_workers: int = DEFAULT_N_THREADS
-    existing_policy: ExistingPolicy = ExistingPolicy.ERROR
-    descriptive_names: bool = False
-
-    def options(self) -> DownloadOptions:
-        return DownloadOptions(first=self.first, last=self.last, size=self.size, n_workers=self.n_workers)
-
-    def validate(self) -> DownloadParams:
-        self.options().validate()
-        if not self.url.strip():
-            from antenati.errors import ValidationError
-
-            raise ValidationError('url must not be empty')
-        if not self.output_dir.strip():
-            from antenati.errors import ValidationError
-
-            raise ValidationError('output directory must not be empty')
-        return self
+class DownloadParams(DownloadConfig):
+    """Backward-compatible GUI name for the shared download configuration."""
 
 
 class DownloaderFactory(Protocol):
@@ -88,7 +66,7 @@ class DownloadWorker:
         self._thread: threading.Thread | None = None
 
     def start(self, params: DownloadParams) -> None:
-        params.validate()
+        params.validate(require_output=True)
         if self._thread is not None and self._thread.is_alive():
             raise RuntimeError('A download is already in progress')
         self._cancel.clear()
@@ -107,7 +85,7 @@ class DownloadWorker:
 
     def _run(self, params: DownloadParams) -> None:
         try:
-            params.validate()
+            params.validate(require_output=True)
             downloader = self._factory(params.url, params.first, params.last, params.descriptive_names)
             downloader.load()
             prepare_output(downloader, params.output_dir, params.existing_policy)

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -1,25 +1,6 @@
 # SPDX-FileCopyrightText: 2018 Giovanni Cerretani
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Background download worker for the Tk GUI.
-
-The worker runs the entire ``Downloader`` lifecycle (construction, manifest
-fetch, image downloads) on a dedicated ``threading.Thread`` and reports
-back to the main thread by pushing events onto a :class:`queue.Queue`.
-The Tk event loop then polls that queue with ``root.after`` and updates
-the UI without blocking.
-
-Compared to the legacy ``ThreadPoolExecutor(max_workers=1) +
-wait_variable`` pattern this gives us three things:
-
-1. The main loop is never blocked, so the window keeps repainting
-   (and the Cancel button can be clicked) while the download runs.
-2. Exceptions surface cleanly via a ``Failed`` event with the full
-   message; they no longer get swallowed by the ``with`` cleanup.
-3. The whole thing is dependency-free for tests — :func:`run_worker`
-   only needs a ``DownloaderFactory`` callable and a ``ProgressBar`` to
-   pump events into a queue, so unit tests can exercise the state
-   machine without any Tk import.
-"""
+"""Background download worker for the Tk GUI."""
 
 from __future__ import annotations
 
@@ -29,7 +10,7 @@ import threading
 from dataclasses import dataclass
 from typing import Protocol
 
-from antenati.downloader import DEFAULT_N_THREADS, Downloader, ProgressBar
+from antenati.downloader import DEFAULT_N_THREADS, DownloadReport, Downloader, ProgressBar
 
 logger = logging.getLogger(__name__)
 
@@ -48,19 +29,21 @@ class Tick:
 
 @dataclass(frozen=True)
 class Done:
-    """All images processed; ``total_bytes`` is the cumulative download size."""
+    """Execution finished; ``report`` contains the complete outcome."""
 
-    total_bytes: int
+    report: DownloadReport
 
 
 @dataclass(frozen=True)
 class Cancelled:
     """The user clicked Cancel and the worker honoured the request."""
 
+    report: DownloadReport
+
 
 @dataclass(frozen=True)
 class Failed:
-    """The worker hit an unrecoverable error before completing."""
+    """The worker hit an unrecoverable error before producing a report."""
 
     message: str
 
@@ -81,8 +64,6 @@ class DownloadParams:
 
 
 class DownloaderFactory(Protocol):
-    """Callable that builds a Downloader. Tests inject a fake here."""
-
     def __call__(self, url: str, first: int, last: int | None) -> Downloader: ...
 
 
@@ -100,7 +81,6 @@ class DownloadWorker:
         self._thread: threading.Thread | None = None
 
     def start(self, params: DownloadParams) -> None:
-        """Spawn the download thread. Returns immediately."""
         if self._thread is not None and self._thread.is_alive():
             raise RuntimeError('A download is already in progress')
         self._cancel.clear()
@@ -108,33 +88,31 @@ class DownloadWorker:
         self._thread.start()
 
     def cancel(self) -> None:
-        """Ask the running download to stop at the next canvas boundary."""
         self._cancel.set()
 
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
     def join(self, timeout: float | None = None) -> None:
-        """Wait for the worker to finish (mainly useful in tests)."""
         if self._thread is not None:
             self._thread.join(timeout)
 
     def _run(self, params: DownloadParams) -> None:
         try:
             downloader = self._factory(params.url, params.first, params.last)
+            downloader.load()
             downloader.check_dir(params.parent_dir, interactive=False)
-
             progress = ProgressBar(
                 set_total=lambda total: self.events.put(Progress(total=total)),
                 update=lambda: self.events.put(Tick()),
             )
-            total_bytes = downloader.run(params.n_workers, params.size, progress, cancel=self._cancel)
+            report = downloader.run(params.n_workers, params.size, progress, cancel=self._cancel)
         except Exception as ex:
             logger.exception('Download worker failed')
             self.events.put(Failed(message=str(ex)))
             return
 
-        if self._cancel.is_set():
-            self.events.put(Cancelled())
+        if report.cancelled:
+            self.events.put(Cancelled(report=report))
         else:
-            self.events.put(Done(total_bytes=total_bytes))
+            self.events.put(Done(report=report))

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -12,7 +12,6 @@ from typing import Protocol
 
 from antenati.config import DownloadConfig
 from antenati.downloader import Downloader, DownloadReport, ProgressBar
-from antenati.gui.worker import *
 from antenati.output import ExistingPolicy, prepare_output, run_with_policy
 
 logger = logging.getLogger(__name__)

--- a/src/antenati/gui/worker.py
+++ b/src/antenati/gui/worker.py
@@ -11,40 +11,33 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from antenati.downloader import DEFAULT_N_THREADS, DownloadReport, Downloader, ProgressBar
+from antenati.validation import DownloadOptions
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class Progress:
-    """Total work-units have been announced by the downloader."""
-
     total: int
 
 
 @dataclass(frozen=True)
 class Tick:
-    """A single image finished (success or failure)."""
+    pass
 
 
 @dataclass(frozen=True)
 class Done:
-    """Execution finished; ``report`` contains the complete outcome."""
-
     report: DownloadReport
 
 
 @dataclass(frozen=True)
 class Cancelled:
-    """The user clicked Cancel and the worker honoured the request."""
-
     report: DownloadReport
 
 
 @dataclass(frozen=True)
 class Failed:
-    """The worker hit an unrecoverable error before producing a report."""
-
     message: str
 
 
@@ -53,14 +46,27 @@ WorkerEvent = Progress | Tick | Done | Cancelled | Failed
 
 @dataclass
 class DownloadParams:
-    """Inputs the worker needs to start a download."""
-
     url: str
     parent_dir: str
     size: int
     first: int
     last: int | None
     n_workers: int = DEFAULT_N_THREADS
+
+    def options(self) -> DownloadOptions:
+        return DownloadOptions(first=self.first, last=self.last, size=self.size, n_workers=self.n_workers)
+
+    def validate(self) -> DownloadParams:
+        self.options().validate()
+        if not self.url.strip():
+            from antenati.errors import ValidationError
+
+            raise ValidationError('url must not be empty')
+        if not self.parent_dir.strip():
+            from antenati.errors import ValidationError
+
+            raise ValidationError('destination folder must not be empty')
+        return self
 
 
 class DownloaderFactory(Protocol):
@@ -72,8 +78,6 @@ def _default_factory(url: str, first: int, last: int | None) -> Downloader:
 
 
 class DownloadWorker:
-    """Run a download on a background thread, surface events on a Queue."""
-
     def __init__(self, factory: DownloaderFactory = _default_factory) -> None:
         self._factory = factory
         self.events: queue.Queue[WorkerEvent] = queue.Queue()
@@ -81,6 +85,7 @@ class DownloadWorker:
         self._thread: threading.Thread | None = None
 
     def start(self, params: DownloadParams) -> None:
+        params.validate()
         if self._thread is not None and self._thread.is_alive():
             raise RuntimeError('A download is already in progress')
         self._cancel.clear()
@@ -99,6 +104,7 @@ class DownloadWorker:
 
     def _run(self, params: DownloadParams) -> None:
         try:
+            params.validate()
             downloader = self._factory(params.url, params.first, params.last)
             downloader.load()
             downloader.check_dir(params.parent_dir, interactive=False)

--- a/src/antenati/http.py
+++ b/src/antenati/http.py
@@ -61,15 +61,19 @@ def build_session() -> Session:
 def fetch(session: Session, url: str, *, stream: bool = False) -> Response:
     logger.debug('GET %s', url)
     reply = session.get(url, timeout=DEFAULT_TIMEOUT, stream=stream)
-    reply.raise_for_status()
-    if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
-        logger.warning('WAF challenge received from %s', reply.url)
-        raise WafChallengeError(
-            f'{reply.url}: AWS WAF challenge cannot be bypassed. '
-            'Workaround: open the gallery page in a browser, copy the "IIIF manifest" link '
-            'at the bottom of the left panel and pass that URL to this tool instead. '
-            'See https://github.com/gcerretani/antenati/issues/25 for details.'
-        )
+    try:
+        reply.raise_for_status()
+        if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
+            logger.warning('WAF challenge received from %s', reply.url)
+            raise WafChallengeError(
+                f'{reply.url}: AWS WAF challenge cannot be bypassed. '
+                'Workaround: open the gallery page in a browser, copy the "IIIF manifest" link '
+                'at the bottom of the left panel and pass that URL to this tool instead. '
+                'See https://github.com/gcerretani/antenati/issues/25 for details.'
+            )
+    except Exception:
+        reply.close()
+        raise
     return reply
 
 

--- a/src/antenati/http.py
+++ b/src/antenati/http.py
@@ -1,24 +1,6 @@
 # SPDX-FileCopyrightText: 2018 Giovanni Cerretani
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""HTTP plumbing for the Portale Antenati downloader.
-
-Exposes a single small surface that the rest of the package leans on
-without re-implementing the SAN-server quirks:
-
-- :func:`build_session` returns a :class:`requests.Session` preconfigured
-  with the browser-like headers required by the SAN reverse proxy and an
-  ``urllib3.util.Retry`` adapter that transparently retries on transient
-  5xx and rate-limit responses.
-- :func:`fetch` performs a ``GET`` with bounded connect/read timeouts and
-  turns the AWS WAF challenge response (HTTP 202 with
-  ``x-amzn-waf-action: challenge``) into a typed
-  :class:`antenati.errors.WafChallengeError`.
-- :func:`get_content_type` / :func:`get_content_charset` parse a
-  response's ``Content-Type`` header.
-
-The module is side-effect free at import time apart from defining constants
-and a logger; callers decide how logging is configured.
-"""
+"""HTTP plumbing for the Portale Antenati downloader."""
 
 from __future__ import annotations
 
@@ -34,36 +16,26 @@ from antenati.errors import WafChallengeError
 
 logger = logging.getLogger(__name__)
 
-# These values describe the soft-failure contract observed from the SAN's
-# AWS WAF. Keeping them named makes challenge detection explicit and keeps
-# tests independent from magic literals sprinkled through request code.
 WAF_CHALLENGE_STATUS: int = 202
 WAF_CHALLENGE_HEADER: str = 'x-amzn-waf-action'
 WAF_CHALLENGE_VALUE: str = 'challenge'
 
-# Retry only transient/rate-limit failures. The conservative exponential
-# backoff is intentional: retry enough to ride out short SAN outages without
-# turning the downloader itself into extra load during an incident.
 RETRY_TOTAL: int = 5
 RETRY_BACKOFF_FACTOR: float = 0.5
 RETRYABLE_STATUSES: tuple[int, ...] = (429, 500, 502, 503, 504)
 
-# Requests interprets a two-tuple as (connect timeout, read timeout). The
-# read timeout is an inactivity timeout, not a total-transfer deadline, but
-# it prevents a dead peer from keeping a worker blocked forever.
 CONNECT_TIMEOUT_SECONDS: float = 10.0
 READ_TIMEOUT_SECONDS: float = 60.0
 DEFAULT_TIMEOUT: tuple[float, float] = (CONNECT_TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS)
 
-# The SAN reverse proxy has historically rejected requests that look like
-# generic automation. These browser-like headers are therefore part of the
-# compatibility contract rather than cosmetic metadata.
-_USER_AGENT: str = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
+_USER_AGENT: str = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+    '(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
+)
 _REFERER: str = 'https://antenati.cultura.gov.it/'
 
 
 def _http_headers():
-    """Build the header set required to reach the Portale Antenati."""
     headers = default_headers()
     headers['User-Agent'] = _USER_AGENT
     headers['Referer'] = _REFERER
@@ -71,7 +43,6 @@ def _http_headers():
 
 
 def _retry_policy() -> Retry:
-    """Return the urllib3 Retry policy mounted on every Session."""
     return Retry(
         total=RETRY_TOTAL,
         backoff_factor=RETRY_BACKOFF_FACTOR,
@@ -82,7 +53,6 @@ def _retry_policy() -> Retry:
 
 
 def build_session() -> Session:
-    """Return a Session preconfigured for Portale Antenati requests."""
     session = Session()
     session.headers = _http_headers()
     adapter = HTTPAdapter(max_retries=_retry_policy())
@@ -91,17 +61,10 @@ def build_session() -> Session:
     return session
 
 
-def fetch(session: Session, url: str) -> Response:
-    """GET ``url`` and turn known SAN soft-failures into typed errors.
-
-    Retryable 429/5xx responses are handled by the Session adapter before
-    this function sees the final response. Ordinary HTTP errors are raised
-    through ``raise_for_status()``. A WAF challenge is different: it is a
-    202 response, so it must be detected explicitly and converted into a
-    :class:`WafChallengeError` with the direct-manifest workaround.
-    """
+def fetch(session: Session, url: str, *, stream: bool = False) -> Response:
+    """GET ``url`` with retries/timeouts; optionally leave the body streamed."""
     logger.debug('GET %s', url)
-    reply = session.get(url, timeout=DEFAULT_TIMEOUT)
+    reply = session.get(url, timeout=DEFAULT_TIMEOUT, stream=stream)
     reply.raise_for_status()
     if reply.status_code == WAF_CHALLENGE_STATUS and reply.headers.get(WAF_CHALLENGE_HEADER) == WAF_CHALLENGE_VALUE:
         logger.warning('WAF challenge received from %s', reply.url)
@@ -115,14 +78,19 @@ def fetch(session: Session, url: str) -> Response:
 
 
 def get_content_type(reply: Response) -> str:
-    """Return the bare content-type (no parameters) from a response."""
+    """Return the bare content type or raise a controlled error if absent."""
+    raw = reply.headers.get('Content-Type')
+    if not raw:
+        raise ValueError(f'{reply.url}: response has no Content-Type header')
     msg = Message()
-    msg['Content-Type'] = reply.headers['Content-Type']
+    msg['Content-Type'] = raw
     return msg.get_content_type()
 
 
 def get_content_charset(reply: Response) -> str | None:
-    """Return the charset declared in a response's Content-Type, if any."""
+    raw = reply.headers.get('Content-Type')
+    if not raw:
+        return None
     msg = Message()
-    msg['Content-Type'] = reply.headers['Content-Type']
+    msg['Content-Type'] = raw
     return msg.get_content_charset()

--- a/src/antenati/http.py
+++ b/src/antenati/http.py
@@ -12,7 +12,7 @@ from requests.adapters import HTTPAdapter
 from requests.utils import default_headers
 from urllib3.util.retry import Retry
 
-from antenati.errors import WafChallengeError
+from antenati.errors import HttpMetadataError, WafChallengeError
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,6 @@ def build_session() -> Session:
 
 
 def fetch(session: Session, url: str, *, stream: bool = False) -> Response:
-    """GET ``url`` with retries/timeouts; optionally leave the body streamed."""
     logger.debug('GET %s', url)
     reply = session.get(url, timeout=DEFAULT_TIMEOUT, stream=stream)
     reply.raise_for_status()
@@ -78,10 +77,9 @@ def fetch(session: Session, url: str, *, stream: bool = False) -> Response:
 
 
 def get_content_type(reply: Response) -> str:
-    """Return the bare content type or raise a controlled error if absent."""
     raw = reply.headers.get('Content-Type')
     if not raw:
-        raise ValueError(f'{reply.url}: response has no Content-Type header')
+        raise HttpMetadataError(f'{reply.url}: response has no Content-Type header')
     msg = Message()
     msg['Content-Type'] = raw
     return msg.get_content_type()

--- a/src/antenati/http.py
+++ b/src/antenati/http.py
@@ -28,10 +28,7 @@ CONNECT_TIMEOUT_SECONDS: float = 10.0
 READ_TIMEOUT_SECONDS: float = 60.0
 DEFAULT_TIMEOUT: tuple[float, float] = (CONNECT_TIMEOUT_SECONDS, READ_TIMEOUT_SECONDS)
 
-_USER_AGENT: str = (
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-    '(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
-)
+_USER_AGENT: str = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0'
 _REFERER: str = 'https://antenati.cultura.gov.it/'
 
 

--- a/src/antenati/image.py
+++ b/src/antenati/image.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2018 Giovanni Cerretani
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Lightweight validation for downloaded image payloads."""
+
+from __future__ import annotations
+
+from antenati.errors import ImageValidationError
+
+_SUPPORTED_MIME: dict[str, tuple[str, str]] = {
+    'image/jpeg': ('jpeg', '.jpg'),
+    'image/png': ('png', '.png'),
+    'image/tiff': ('tiff', '.tif'),
+    'image/webp': ('webp', '.webp'),
+}
+
+
+def _detect_format(data: bytes) -> str | None:
+    if len(data) >= 4 and data.startswith(b'\xff\xd8\xff') and data.endswith(b'\xff\xd9'):
+        return 'jpeg'
+    if data.startswith(b'\x89PNG\r\n\x1a\n'):
+        return 'png'
+    if data.startswith((b'II*\x00', b'MM\x00*')):
+        return 'tiff'
+    if len(data) >= 12 and data.startswith(b'RIFF') and data[8:12] == b'WEBP':
+        return 'webp'
+    return None
+
+
+def validate_image_bytes(content_type: str, data: bytes) -> str:
+    """Validate MIME/signature agreement and return the canonical extension."""
+    declared = _SUPPORTED_MIME.get(content_type.lower())
+    if declared is None:
+        raise ImageValidationError(f'Unsupported image media type: {content_type}')
+    detected = _detect_format(data)
+    if detected is None:
+        raise ImageValidationError(f'Invalid or corrupt {content_type} payload')
+    expected_format, extension = declared
+    if detected != expected_format:
+        raise ImageValidationError(
+            f'Image media type mismatch: declared {content_type}, detected {detected}'
+        )
+    return extension

--- a/src/antenati/image.py
+++ b/src/antenati/image.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from antenati.errors import ImageValidationError
 
 _SUPPORTED_MIME: dict[str, tuple[str, str]] = {
@@ -14,29 +16,50 @@ _SUPPORTED_MIME: dict[str, tuple[str, str]] = {
 }
 
 
-def _detect_format(data: bytes) -> str | None:
-    if len(data) >= 4 and data.startswith(b'\xff\xd8\xff') and data.endswith(b'\xff\xd9'):
+def _detect_format(head: bytes, tail: bytes) -> str | None:
+    if len(head) >= 3 and head.startswith(b'\xff\xd8\xff') and tail.endswith(b'\xff\xd9'):
         return 'jpeg'
-    if data.startswith(b'\x89PNG\r\n\x1a\n'):
+    if head.startswith(b'\x89PNG\r\n\x1a\n'):
         return 'png'
-    if data.startswith((b'II*\x00', b'MM\x00*')):
+    if head.startswith((b'II*\x00', b'MM\x00*')):
         return 'tiff'
-    if len(data) >= 12 and data.startswith(b'RIFF') and data[8:12] == b'WEBP':
+    if len(head) >= 12 and head.startswith(b'RIFF') and head[8:12] == b'WEBP':
         return 'webp'
     return None
 
 
-def validate_image_bytes(content_type: str, data: bytes) -> str:
-    """Validate MIME/signature agreement and return the canonical extension."""
+def extension_for_media_type(content_type: str) -> str:
     declared = _SUPPORTED_MIME.get(content_type.lower())
     if declared is None:
         raise ImageValidationError(f'Unsupported image media type: {content_type}')
-    detected = _detect_format(data)
+    return declared[1]
+
+
+def _validate(content_type: str, head: bytes, tail: bytes) -> str:
+    declared = _SUPPORTED_MIME.get(content_type.lower())
+    if declared is None:
+        raise ImageValidationError(f'Unsupported image media type: {content_type}')
+    detected = _detect_format(head, tail)
     if detected is None:
         raise ImageValidationError(f'Invalid or corrupt {content_type} payload')
     expected_format, extension = declared
     if detected != expected_format:
-        raise ImageValidationError(
-            f'Image media type mismatch: declared {content_type}, detected {detected}'
-        )
+        raise ImageValidationError(f'Image media type mismatch: declared {content_type}, detected {detected}')
     return extension
+
+
+def validate_image_bytes(content_type: str, data: bytes) -> str:
+    """Validate MIME/signature agreement for an in-memory payload."""
+    return _validate(content_type, data[:16], data[-16:])
+
+
+def validate_image_file(content_type: str, path: Path) -> str:
+    """Validate a streamed image without loading the complete file into memory."""
+    with path.open('rb') as stream:
+        head = stream.read(16)
+        try:
+            stream.seek(-16, 2)
+        except OSError:
+            stream.seek(0)
+        tail = stream.read(16)
+    return _validate(content_type, head, tail)

--- a/src/antenati/output.py
+++ b/src/antenati/output.py
@@ -16,6 +16,7 @@ from antenati.downloader import Downloader, DownloadItem, DownloadReport, Progre
 class ExistingPolicy(str, Enum):
     """How to handle a destination that already contains planned files."""
 
+    ASK = 'ask'
     ERROR = 'error'
     OVERWRITE = 'overwrite'
     SKIP = 'skip'
@@ -34,9 +35,27 @@ def planned_path(directory: Path, item: DownloadItem) -> Path:
     return directory / f'{item.stem}{suffix}'
 
 
+def output_directory(downloader: Downloader, output: str | Path | None) -> Path:
+    """Return the exact output path selected for a run."""
+    return Path(output) if output is not None else downloader.dirname
+
+
+def existing_output_requires_decision(downloader: Downloader, output: str | Path | None) -> bool:
+    """Return whether ``ask`` needs the interface to choose a concrete policy."""
+    directory = output_directory(downloader, output)
+    return directory.exists() and directory.is_dir() and any(directory.iterdir())
+
+
 def prepare_output(downloader: Downloader, output: str | Path | None, policy: ExistingPolicy) -> Path:
-    """Resolve/create the exact destination directory according to ``policy``."""
-    directory = Path(output) if output is not None else downloader.dirname
+    """Resolve/create the exact destination directory according to ``policy``.
+
+    ``ask`` is intentionally not handled here: interaction belongs to the CLI
+    or GUI. Those surfaces must resolve it to a concrete policy first.
+    """
+    if policy is ExistingPolicy.ASK:
+        raise RuntimeError('ExistingPolicy.ASK must be resolved by the interface before execution')
+
+    directory = output_directory(downloader, output)
     downloader.dirname = directory
     if directory.exists():
         if not directory.is_dir():
@@ -81,8 +100,10 @@ def run_with_policy(
     downloads planned pages. ``resume`` reuses only hash-verified provenance
     and redownloads stale/corrupt files. ``skip`` also reuses verified files,
     but refuses to overwrite an unverified file that already occupies a
-    planned path.
+    planned path. ``ask`` must be resolved by the interface before this point.
     """
+    if policy is ExistingPolicy.ASK:
+        raise RuntimeError('ExistingPolicy.ASK must be resolved by the interface before execution')
     if policy is ExistingPolicy.SKIP:
         _validate_skip_policy(downloader, size)
     return downloader.run(

--- a/src/antenati/output.py
+++ b/src/antenati/output.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2018 Giovanni Cerretani
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Output-directory and existing-file policy helpers."""
+
+from __future__ import annotations
+
+import threading
+from enum import Enum
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from antenati import provenance
+from antenati.downloader import DownloadItem, DownloadReport, Downloader, ProgressBar
+
+
+class ExistingPolicy(str, Enum):
+    """How to handle a destination that already contains planned files."""
+
+    ERROR = 'error'
+    OVERWRITE = 'overwrite'
+    SKIP = 'skip'
+    RESUME = 'resume'
+
+
+def planned_path(directory: Path, item: DownloadItem) -> Path:
+    """Return the expected local image path without requesting the body."""
+    suffix = Path(urlsplit(item.source_url).path).suffix.lower()
+    if suffix in {'.jpeg', '.jpe'}:
+        suffix = '.jpg'
+    if suffix == '.tiff':
+        suffix = '.tif'
+    if suffix not in {'.jpg', '.png', '.tif', '.webp'}:
+        suffix = '.img'
+    return directory / f'{item.stem}{suffix}'
+
+
+def prepare_output(downloader: Downloader, output: str | Path | None, policy: ExistingPolicy) -> Path:
+    """Resolve/create the exact destination directory according to ``policy``."""
+    directory = Path(output) if output is not None else downloader.dirname
+    downloader.dirname = directory
+    if directory.exists():
+        if not directory.is_dir():
+            raise RuntimeError(f'Output path is not a directory: {directory}')
+        if policy is ExistingPolicy.ERROR and any(directory.iterdir()):
+            raise RuntimeError(f'Output directory already exists and is not empty: {directory}')
+    else:
+        directory.mkdir(parents=True)
+    return directory
+
+
+def _validate_skip_policy(downloader: Downloader, size: int) -> None:
+    """Refuse to overwrite an existing unverified file under ``skip`` policy."""
+    plan = downloader.plan(size)
+    verified = provenance.verified_resume_records(
+        downloader.dirname,
+        manifest_url=downloader.manifest_url,
+        requested_size=size,
+    )
+    verified_keys = set(verified)
+    for item in plan.items:
+        candidate = planned_path(downloader.dirname, item)
+        key = (str(item.canvas.get('@id', '')), item.source_url)
+        if candidate.exists() and key not in verified_keys:
+            raise RuntimeError(
+                f'{candidate}: existing file is not verified for this source/resolution; '
+                'use resume to verify/redownload it or overwrite to replace it'
+            )
+
+
+def run_with_policy(
+    downloader: Downloader,
+    *,
+    n_workers: int,
+    size: int,
+    progress: ProgressBar,
+    policy: ExistingPolicy,
+    cancel: threading.Event | None = None,
+) -> DownloadReport:
+    """Execute with deterministic existing-file semantics.
+
+    ``error`` is enforced while preparing the directory. ``overwrite`` always
+    downloads planned pages. ``resume`` reuses only hash-verified provenance
+    and redownloads stale/corrupt files. ``skip`` also reuses verified files,
+    but refuses to overwrite an unverified file that already occupies a
+    planned path.
+    """
+    if policy is ExistingPolicy.SKIP:
+        _validate_skip_policy(downloader, size)
+    return downloader.run(
+        n_workers=n_workers,
+        size=size,
+        progress=progress,
+        cancel=cancel,
+        resume=policy in {ExistingPolicy.RESUME, ExistingPolicy.SKIP},
+    )

--- a/src/antenati/output.py
+++ b/src/antenati/output.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from antenati import provenance
-from antenati.downloader import DownloadItem, DownloadReport, Downloader, ProgressBar
+from antenati.downloader import Downloader, DownloadItem, DownloadReport, ProgressBar
 
 
 class ExistingPolicy(str, Enum):
@@ -62,8 +62,7 @@ def _validate_skip_policy(downloader: Downloader, size: int) -> None:
         key = (str(item.canvas.get('@id', '')), item.source_url)
         if candidate.exists() and key not in verified_keys:
             raise RuntimeError(
-                f'{candidate}: existing file is not verified for this source/resolution; '
-                'use resume to verify/redownload it or overwrite to replace it'
+                f'{candidate}: existing file is not verified for this source/resolution; use resume to verify/redownload it or overwrite to replace it'
             )
 
 

--- a/src/antenati/provenance.py
+++ b/src/antenati/provenance.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2018 Giovanni Cerretani
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Persistent provenance metadata for downloaded Antenati galleries."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+MANIFEST_FILENAME = '.antenati-manifest.json'
+INDEX_FILENAME = '.antenati-index.json'
+INDEX_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ImageRecord:
+    """Persistent mapping from one local file to its IIIF source."""
+
+    canvas_id: str
+    label: str
+    source_url: str
+    filename: str
+    requested_size: int
+    byte_size: int
+    sha256: str
+    downloaded_at: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        canvas_id: str,
+        label: str,
+        source_url: str,
+        filename: str,
+        requested_size: int,
+        byte_size: int,
+        sha256: str,
+    ) -> ImageRecord:
+        return cls(
+            canvas_id=canvas_id,
+            label=label,
+            source_url=source_url,
+            filename=filename,
+            requested_size=requested_size,
+            byte_size=byte_size,
+            sha256=sha256,
+            downloaded_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace a metadata file atomically in its destination directory."""
+    temp_name: str | None = None
+    try:
+        with NamedTemporaryFile(mode='w', encoding='utf-8', dir=path.parent, prefix=f'.{path.name}.', suffix='.tmp', delete=False) as tmp:
+            temp_name = tmp.name
+            tmp.write(text)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(temp_name, path)
+        temp_name = None
+    finally:
+        if temp_name is not None:
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+
+def write_provenance(
+    directory: Path,
+    *,
+    source_url: str,
+    manifest_url: str,
+    manifest: dict[str, Any],
+    archive_id: str,
+    ark_id: str,
+    requested_size: int,
+    records: list[ImageRecord],
+) -> None:
+    """Persist the normalized manifest and a per-image provenance index."""
+    manifest_text = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+    _atomic_write_text(directory / MANIFEST_FILENAME, manifest_text)
+
+    payload = {
+        'schema_version': INDEX_SCHEMA_VERSION,
+        'source_url': source_url,
+        'manifest_url': manifest_url,
+        'archive_id': archive_id,
+        'ark_id': ark_id,
+        'requested_size': requested_size,
+        'images': [asdict(record) for record in records],
+    }
+    index_text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
+    _atomic_write_text(directory / INDEX_FILENAME, index_text)
+
+
+def read_index(directory: Path) -> dict[str, Any] | None:
+    """Return a previously persisted index, or ``None`` when absent."""
+    path = directory / INDEX_FILENAME
+    if not path.exists():
+        return None
+    with path.open(encoding='utf-8') as stream:
+        data = json.load(stream)
+    if not isinstance(data, dict):
+        raise ValueError(f'{path}: provenance index must contain a JSON object')
+    return data

--- a/src/antenati/provenance.py
+++ b/src/antenati/provenance.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2018 Giovanni Cerretani
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Persistent provenance metadata for downloaded Antenati galleries."""
+"""Persistent provenance metadata and resume verification."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -19,8 +20,6 @@ INDEX_SCHEMA_VERSION = 1
 
 @dataclass(frozen=True)
 class ImageRecord:
-    """Persistent mapping from one local file to its IIIF source."""
-
     canvas_id: str
     label: str
     source_url: str
@@ -53,12 +52,54 @@ class ImageRecord:
             downloaded_at=datetime.now(timezone.utc).isoformat(),
         )
 
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> ImageRecord:
+        try:
+            return cls(
+                canvas_id=str(value['canvas_id']),
+                label=str(value['label']),
+                source_url=str(value['source_url']),
+                filename=str(value['filename']),
+                requested_size=int(value['requested_size']),
+                byte_size=int(value['byte_size']),
+                sha256=str(value['sha256']),
+                downloaded_at=str(value['downloaded_at']),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError('Invalid image record in provenance index') from exc
+
+
+def file_sha256(path: Path) -> str:
+    digest = sha256()
+    with path.open('rb') as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_record(directory: Path, record: ImageRecord) -> bool:
+    """Return True only when the indexed local file still matches size/hash."""
+    candidate = directory / record.filename
+    try:
+        stat = candidate.stat()
+    except FileNotFoundError:
+        return False
+    if not candidate.is_file() or stat.st_size != record.byte_size:
+        return False
+    return file_sha256(candidate) == record.sha256
+
 
 def _atomic_write_text(path: Path, text: str) -> None:
-    """Replace a metadata file atomically in its destination directory."""
     temp_name: str | None = None
     try:
-        with NamedTemporaryFile(mode='w', encoding='utf-8', dir=path.parent, prefix=f'.{path.name}.', suffix='.tmp', delete=False) as tmp:
+        with NamedTemporaryFile(
+            mode='w',
+            encoding='utf-8',
+            dir=path.parent,
+            prefix=f'.{path.name}.',
+            suffix='.tmp',
+            delete=False,
+        ) as tmp:
             temp_name = tmp.name
             tmp.write(text)
             tmp.flush()
@@ -84,7 +125,6 @@ def write_provenance(
     requested_size: int,
     records: list[ImageRecord],
 ) -> None:
-    """Persist the normalized manifest and a per-image provenance index."""
     manifest_text = json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + '\n'
     _atomic_write_text(directory / MANIFEST_FILENAME, manifest_text)
 
@@ -102,7 +142,6 @@ def write_provenance(
 
 
 def read_index(directory: Path) -> dict[str, Any] | None:
-    """Return a previously persisted index, or ``None`` when absent."""
     path = directory / INDEX_FILENAME
     if not path.exists():
         return None
@@ -111,3 +150,37 @@ def read_index(directory: Path) -> dict[str, Any] | None:
     if not isinstance(data, dict):
         raise ValueError(f'{path}: provenance index must contain a JSON object')
     return data
+
+
+def verified_resume_records(
+    directory: Path,
+    *,
+    manifest_url: str,
+    requested_size: int,
+) -> dict[tuple[str, str], ImageRecord]:
+    """Return only records safe to reuse for this manifest and resolution."""
+    index = read_index(directory)
+    if index is None:
+        return {}
+    if index.get('schema_version') != INDEX_SCHEMA_VERSION:
+        return {}
+    if index.get('manifest_url') != manifest_url:
+        return {}
+    if index.get('requested_size') != requested_size:
+        return {}
+
+    result: dict[tuple[str, str], ImageRecord] = {}
+    images = index.get('images', [])
+    if not isinstance(images, list):
+        return {}
+    for raw in images:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            record = ImageRecord.from_mapping(raw)
+        except ValueError:
+            continue
+        if record.requested_size != requested_size or not verify_record(directory, record):
+            continue
+        result[(record.canvas_id, record.source_url)] = record
+    return result

--- a/src/antenati/provenance.py
+++ b/src/antenati/provenance.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+from collections.abc import Collection
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from hashlib import sha256
@@ -151,13 +152,13 @@ def read_index(directory: Path) -> dict[str, Any] | None:
     return data
 
 
-def verified_resume_records(
+def _indexed_records(
     directory: Path,
     *,
     manifest_url: str,
     requested_size: int,
 ) -> dict[tuple[str, str], ImageRecord]:
-    """Return only records safe to reuse for this manifest and resolution."""
+    """Return every record from the index that matches this manifest and resolution."""
     index = read_index(directory)
     if index is None:
         return {}
@@ -168,10 +169,10 @@ def verified_resume_records(
     if index.get('requested_size') != requested_size:
         return {}
 
-    result: dict[tuple[str, str], ImageRecord] = {}
     images = index.get('images', [])
     if not isinstance(images, list):
         return {}
+    result: dict[tuple[str, str], ImageRecord] = {}
     for raw in images:
         if not isinstance(raw, dict):
             continue
@@ -179,7 +180,28 @@ def verified_resume_records(
             record = ImageRecord.from_mapping(raw)
         except ValueError:
             continue
-        if record.requested_size != requested_size or not verify_record(directory, record):
-            continue
         result[(record.canvas_id, record.source_url)] = record
     return result
+
+
+def verified_resume_records(
+    directory: Path,
+    *,
+    manifest_url: str,
+    requested_size: int,
+) -> dict[tuple[str, str], ImageRecord]:
+    """Return only records safe to reuse for this manifest and resolution."""
+    candidates = _indexed_records(directory, manifest_url=manifest_url, requested_size=requested_size)
+    return {key: record for key, record in candidates.items() if verify_record(directory, record)}
+
+
+def carry_over_records(
+    directory: Path,
+    *,
+    manifest_url: str,
+    requested_size: int,
+    exclude_keys: Collection[tuple[str, str]],
+) -> list[ImageRecord]:
+    """Return previously indexed records outside this run's plan, so a rewrite doesn't drop them."""
+    candidates = _indexed_records(directory, manifest_url=manifest_url, requested_size=requested_size)
+    return [record for key, record in candidates.items() if key not in exclude_keys]

--- a/src/antenati/provenance.py
+++ b/src/antenati/provenance.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from dataclasses import asdict, dataclass
@@ -108,10 +109,8 @@ def _atomic_write_text(path: Path, text: str) -> None:
         temp_name = None
     finally:
         if temp_name is not None:
-            try:
+            with contextlib.suppress(FileNotFoundError):
                 os.unlink(temp_name)
-            except FileNotFoundError:
-                pass
 
 
 def write_provenance(

--- a/src/antenati/provenance.py
+++ b/src/antenati/provenance.py
@@ -81,7 +81,10 @@ def file_sha256(path: Path) -> str:
 
 def verify_record(directory: Path, record: ImageRecord) -> bool:
     """Return True only when the indexed local file still matches size/hash."""
-    candidate = directory / record.filename
+    name = record.filename
+    if not name or name != Path(name).name:
+        return False
+    candidate = directory / name
     try:
         stat = candidate.stat()
     except FileNotFoundError:

--- a/src/antenati/validation.py
+++ b/src/antenati/validation.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2018 Giovanni Cerretani
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Shared CLI/GUI/programmatic input validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from antenati.errors import ValidationError
+
+MAX_WORKERS = 64
+
+
+@dataclass(frozen=True)
+class DownloadOptions:
+    """Core execution options shared by every user interface."""
+
+    first: int = 0
+    last: int | None = None
+    size: int = 0
+    n_workers: int = 2
+
+    def validate(self) -> DownloadOptions:
+        validate_download_options(self)
+        return self
+
+
+def validate_page_range(first: int, last: int | None) -> None:
+    if first < 0:
+        raise ValidationError('first must be >= 0')
+    if last is not None and last < 0:
+        raise ValidationError('last must be >= 0')
+    if last is not None and last <= first:
+        raise ValidationError('last must be greater than first')
+
+
+def validate_download_options(options: DownloadOptions) -> None:
+    validate_page_range(options.first, options.last)
+    if options.size < 0:
+        raise ValidationError('size must be >= 0')
+    if options.n_workers <= 0:
+        raise ValidationError('n_workers must be > 0')
+    if options.n_workers > MAX_WORKERS:
+        raise ValidationError(f'n_workers must be <= {MAX_WORKERS}')

--- a/tests/integration/test_live_download.py
+++ b/tests/integration/test_live_download.py
@@ -1,17 +1,7 @@
 """Live integration tests against the real Portale Antenati.
 
-These tests are slow, hit third-party services, and may fail when the
-Antenati gallery frontend is under WAF challenge or when one of the IIIF
-backends is unavailable. They are gated by the ``integration`` pytest
-marker and excluded from the normal offline CI matrix.
-
-The live workflow deliberately runs the gallery, direct-manifest and image
-canaries as separate jobs. A gallery-page 403 must not hide whether the
-manifest and image backends are still healthy.
-
-To run locally::
-
-    pytest -m integration
+The gallery frontend, direct manifest backend and image backend are checked
+independently so a WAF failure does not hide the status of the IIIF layers.
 """
 
 from __future__ import annotations
@@ -23,14 +13,7 @@ import pytest
 from antenati import http, iiif
 from antenati.downloader import Downloader, ProgressBar
 
-# Gallery frontend canary. This page has been the project's smoke target
-# since v2.5, but may be blocked for GitHub-hosted runners by the AWS WAF.
 LIVE_GALLERY_URL = 'https://antenati.cultura.gov.it/ark:/12657/an_ua19944535/w9DWR8x'
-
-# Direct IIIF backend canary. Keeping an explicit manifest URL is important:
-# it lets CI check the storage/API layer even when the public gallery HTML is
-# unreachable from the runner. The first canvas currently resolves to a real
-# image on iiif-antenati.cultura.gov.it.
 LIVE_MANIFEST_URL = 'https://dam-antenati.cultura.gov.it/antenati/containers/LzaxZkg/manifest'
 
 
@@ -40,7 +23,6 @@ def _null_progress() -> ProgressBar:
 
 @pytest.mark.integration
 def test_gallery_html_canary() -> None:
-    """Check that the public gallery HTML is reachable and exposes a manifest."""
     session = http.build_session()
     try:
         reply = http.fetch(session, LIVE_GALLERY_URL)
@@ -48,32 +30,30 @@ def test_gallery_html_canary() -> None:
         manifest_url = iiif.parse_manifest_url_from_html(reply.content.decode(charset), LIVE_GALLERY_URL)
     except Exception as exc:
         pytest.fail(f'gallery HTML canary failed for {LIVE_GALLERY_URL}: {exc!r}')
-
     assert manifest_url.startswith('https://'), f'gallery returned an invalid manifest URL: {manifest_url!r}'
 
 
 @pytest.mark.integration
 def test_direct_manifest_canary() -> None:
-    """Check that the IIIF manifest backend works without using gallery HTML."""
     try:
         downloader = Downloader(LIVE_MANIFEST_URL, first=0, last=1)
+        downloader.load()
     except Exception as exc:
         pytest.fail(f'direct manifest canary failed for {LIVE_MANIFEST_URL}: {exc!r}')
-
     assert downloader.gallery_length == 1
     assert downloader.canvases, 'direct manifest returned no canvases'
 
 
 @pytest.mark.integration
 def test_image_download_canary(tmp_path: Path) -> None:
-    """Download one small image through the normal direct-manifest code path."""
     try:
         downloader = Downloader(LIVE_MANIFEST_URL, first=0, last=1)
         downloader.check_dir(parentdir=str(tmp_path), interactive=False)
-        total = downloader.run(n_workers=1, size=200, progress=_null_progress())
+        report = downloader.run(n_workers=1, size=200, progress=_null_progress())
     except Exception as exc:
         pytest.fail(f'image download canary failed via {LIVE_MANIFEST_URL}: {exc!r}')
 
-    files = list(downloader.dirname.iterdir())
-    assert len(files) == 1, f'expected exactly one downloaded image, got {[f.name for f in files]}'
-    assert total > 0, 'image canary downloaded zero bytes'
+    images = [path for path in downloader.dirname.iterdir() if not path.name.startswith('.')]
+    assert len(images) == 1, f'expected exactly one downloaded image, got {[path.name for path in images]}'
+    assert report.successful, f'image canary incomplete: {report}'
+    assert report.bytes_written > 0, 'image canary downloaded zero bytes'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from antenati.config import DownloadConfig
+from antenati.errors import ValidationError
+from antenati.output import ExistingPolicy
+
+
+def test_shared_config_carries_cli_gui_core_options() -> None:
+    config = DownloadConfig(
+        url='https://example.invalid/manifest',
+        output_dir='archive',
+        size=800,
+        first=2,
+        last=5,
+        n_workers=4,
+        descriptive_names=True,
+        existing_policy=ExistingPolicy.RESUME,
+    ).validate(require_output=True)
+    assert config.options().n_workers == 4
+    assert config.descriptive_names
+    assert config.existing_policy is ExistingPolicy.RESUME
+
+
+def test_shared_config_requires_output_for_gui_execution() -> None:
+    config = DownloadConfig(url='https://example.invalid/manifest')
+    with pytest.raises(ValidationError, match='output directory'):
+        config.validate(require_output=True)

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -1,9 +1,4 @@
-"""End-to-end tests for ``Downloader.run`` with mocked HTTP.
-
-These tests are the main safety net: they exercise the full happy path
-(gallery -> manifest -> per-image download -> filesystem writes) and a few
-key failure modes so the upcoming refactor cannot regress them silently.
-"""
+"""End-to-end correctness tests for ``Downloader.run`` with mocked HTTP."""
 
 from __future__ import annotations
 
@@ -24,10 +19,13 @@ def _null_progress() -> ProgressBar:
 
 
 def _image_url(canvas_label: str, size: int) -> str:
-    """Mirror ``__manipulate_url`` for the IIIF URL each canvas will fetch."""
     base = f'https://iiif.example.org/iiif/img{canvas_label[-1]}'
     size_part = f'!{size},{size}' if size > 0 else 'pct:100'
     return f'{base}/full/{size_part}/0/default.jpg'
+
+
+def _image_files(directory: Path) -> list[str]:
+    return sorted(path.name for path in directory.iterdir() if not path.name.startswith('.'))
 
 
 @pytest.fixture
@@ -36,117 +34,74 @@ def downloader_in_tmp(downloader: Downloader, tmp_path: Path) -> Downloader:
     return downloader
 
 
-def test_run_downloads_all_images_full_size(mocked_http, downloader_in_tmp: Downloader) -> None:
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    total = downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
-    assert total == 3 * len(TINY_JPEG)
-    files = sorted(p.name for p in downloader_in_tmp.dirname.iterdir())
-    assert files == ['0001.jpg', '0002.jpg', '0003.jpg']
+def _register_jpegs(mocked_http, labels: tuple[str, ...], size: int = 0) -> None:
+    for label in labels:
+        mocked_http.add(responses.GET, _image_url(label, size), body=TINY_JPEG, status=200, content_type='image/jpeg')
+
+
+def test_run_downloads_all_images_and_returns_consistent_report(mocked_http, downloader_in_tmp: Downloader) -> None:
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    report = downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+    assert report.successful
+    assert report.expected == report.attempted == report.completed == 3
+    assert report.bytes_written == 3 * len(TINY_JPEG)
+    assert _image_files(downloader_in_tmp.dirname) == ['0001.jpg', '0002.jpg', '0003.jpg']
+    assert (downloader_in_tmp.dirname / '.antenati-index.json').is_file()
 
 
 def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: Downloader) -> None:
     size = 1234
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, size),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    total = downloader_in_tmp.run(n_workers=2, size=size, progress=_null_progress())
-    assert total == 3 * len(TINY_JPEG)
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'), size)
+    report = downloader_in_tmp.run(n_workers=2, size=size, progress=_null_progress())
+    assert report.successful
+    assert report.bytes_written == 3 * len(TINY_JPEG)
 
 
-def test_run_partial_failure_raises_with_summary(mocked_http, downloader_in_tmp: Downloader) -> None:
-    # First image succeeds, second 500s, third succeeds.
-    mocked_http.add(
-        responses.GET,
-        _image_url('0001', 0),
-        body=TINY_JPEG,
-        status=200,
-        content_type='image/jpeg',
-    )
-    mocked_http.add(
-        responses.GET,
-        _image_url('0002', 0),
-        body='boom',
-        status=500,
-        content_type='text/plain',
-    )
-    mocked_http.add(
-        responses.GET,
-        _image_url('0003', 0),
-        body=TINY_JPEG,
-        status=200,
-        content_type='image/jpeg',
-    )
-    with pytest.raises(RuntimeError, match=r'Failed to download 1 image'):
-        downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+def test_run_partial_failure_is_structured_not_silent(mocked_http, downloader_in_tmp: Downloader) -> None:
+    mocked_http.add(responses.GET, _image_url('0001', 0), body=TINY_JPEG, status=200, content_type='image/jpeg')
+    mocked_http.add(responses.GET, _image_url('0002', 0), body='boom', status=500, content_type='text/plain')
+    mocked_http.add(responses.GET, _image_url('0003', 0), body=TINY_JPEG, status=200, content_type='image/jpeg')
+    report = downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+    assert not report.successful
+    assert report.completed == 2
+    assert len(report.failed) == 1
+    assert report.failed[0].label == '0002'
 
 
-def test_run_progress_callbacks_are_invoked(mocked_http, downloader_in_tmp: Downloader) -> None:
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    set_total_calls: list[int] = []
-    update_count = [0]
+def test_run_progress_callbacks_match_processed_pages(mocked_http, downloader_in_tmp: Downloader) -> None:
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    totals: list[int] = []
+    ticks = [0]
 
-    def _update() -> None:
-        update_count[0] += 1
+    def update() -> None:
+        ticks[0] += 1
 
-    progress = ProgressBar(set_total=set_total_calls.append, update=_update)
-    downloader_in_tmp.run(n_workers=2, size=0, progress=progress)
-    assert set_total_calls == [3]
-    assert update_count[0] == 3
+    report = downloader_in_tmp.run(n_workers=2, size=0, progress=ProgressBar(totals.append, update))
+    assert report.successful
+    assert totals == [3]
+    assert ticks[0] == 3
 
 
-def test_run_filename_uses_image_extension(mocked_http, tmp_path: Path) -> None:
-    # Construct a downloader with a single canvas served as PNG so we can
-    # observe ``guess_extension`` picking up a different extension.
+def test_run_uses_validated_image_extension(mocked_http, tmp_path: Path) -> None:
     dl = Downloader(GALLERY_URL, first=0, last=1)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
-    mocked_http.add(
-        responses.GET,
-        _image_url('0001', 0),
-        body=TINY_JPEG,  # bytes are irrelevant, content-type drives extension
-        status=200,
-        content_type='image/png',
-    )
-    dl.run(n_workers=1, size=0, progress=_null_progress())
+    png = b'\x89PNG\r\n\x1a\n' + b'payload'
+    mocked_http.add(responses.GET, _image_url('0001', 0), body=png, status=200, content_type='image/png')
+    report = dl.run(n_workers=1, size=0, progress=_null_progress())
+    assert report.successful
     assert (dl.dirname / '0001.png').is_file()
 
 
 def test_run_with_first_last_range_downloads_subset(mocked_http, tmp_path: Path) -> None:
     dl = Downloader(GALLERY_URL, first=1, last=3)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
-    for label in ('0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    dl.run(n_workers=2, size=0, progress=_null_progress())
-    files = sorted(p.name for p in dl.dirname.iterdir())
-    assert files == ['0002.jpg', '0003.jpg']
+    _register_jpegs(mocked_http, ('0002', '0003'))
+    report = dl.run(n_workers=2, size=0, progress=_null_progress())
+    assert report.successful
+    assert _image_files(dl.dirname) == ['0002.jpg', '0003.jpg']
 
 
-def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader_in_tmp: Downloader) -> None:
-    # All three respond with a content-type ``guess_extension`` cannot map.
+def test_unknown_content_type_is_reported_as_failure(mocked_http, downloader_in_tmp: Downloader) -> None:
     for label in ('0001', '0002', '0003'):
         mocked_http.add(
             responses.GET,
@@ -155,21 +110,16 @@ def test_run_unknown_content_type_is_reported_as_failure(mocked_http, downloader
             status=200,
             content_type='application/x-no-such-format',
         )
-    with pytest.raises(RuntimeError, match=r'Failed to download 3 image'):
-        downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+    report = downloader_in_tmp.run(n_workers=2, size=0, progress=_null_progress())
+    assert len(report.failed) == 3
+    assert report.completed == 0
 
 
-def test_run_cli_uses_tqdm_progress_bar(mocked_http, downloader_in_tmp: Downloader) -> None:
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    total = antenati_cli.run_cli(downloader_in_tmp, n_workers=2, size=0)
-    assert total == 3 * len(TINY_JPEG)
+def test_run_cli_returns_same_structured_report(mocked_http, downloader_in_tmp: Downloader) -> None:
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    report = antenati_cli.run_cli(downloader_in_tmp, n_workers=2, size=0)
+    assert report.successful
+    assert report.bytes_written == 3 * len(TINY_JPEG)
 
 
 def test_progress_bar_dataclass_shape() -> None:
@@ -178,39 +128,25 @@ def test_progress_bar_dataclass_shape() -> None:
     assert callable(bar.update)
 
 
-def test_run_honours_preset_cancel_event(mocked_http, downloader_in_tmp: Downloader) -> None:
-    # Register all canvases as 200s; with cancel already set when run()
-    # starts, no fetch should be attempted and the total bytes returned
-    # must be zero. The mock is created with assert_all_requests_are_fired
-    # = False so unused registrations don't fail the test.
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
+def test_run_honours_preset_cancel_event_without_image_requests(mocked_http, downloader_in_tmp: Downloader) -> None:
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    calls_before = len(mocked_http.calls)
     cancel = threading.Event()
     cancel.set()
-    total = downloader_in_tmp.run(n_workers=1, size=0, progress=_null_progress(), cancel=cancel)
-    assert total == 0
+    report = downloader_in_tmp.run(n_workers=1, size=0, progress=_null_progress(), cancel=cancel)
+    assert report.cancelled
+    assert report.attempted == 0
+    assert report.bytes_written == 0
+    assert len(mocked_http.calls) == calls_before
 
 
 def test_run_descriptive_names_embed_ark_and_image_ids(mocked_http, tmp_path: Path) -> None:
     dl = Downloader(GALLERY_URL, first=0, last=None, descriptive_names=True)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    dl.run(n_workers=2, size=0, progress=_null_progress())
-    files = sorted(p.name for p in dl.dirname.iterdir())
-    assert files == [
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    report = dl.run(n_workers=2, size=0, progress=_null_progress())
+    assert report.successful
+    assert _image_files(dl.dirname) == [
         '0001+an_ua19944535+img1.jpg',
         '0002+an_ua19944535+img2.jpg',
         '0003+an_ua19944535+img3.jpg',
@@ -220,15 +156,7 @@ def test_run_descriptive_names_embed_ark_and_image_ids(mocked_http, tmp_path: Pa
 def test_run_from_manifest_url_downloads_all_images(mocked_http, tmp_path: Path) -> None:
     dl = Downloader(MANIFEST_URL, first=0, last=None)
     dl.check_dir(parentdir=str(tmp_path), interactive=False)
-    for label in ('0001', '0002', '0003'):
-        mocked_http.add(
-            responses.GET,
-            _image_url(label, 0),
-            body=TINY_JPEG,
-            status=200,
-            content_type='image/jpeg',
-        )
-    total = dl.run(n_workers=2, size=0, progress=_null_progress())
-    assert total == 3 * len(TINY_JPEG)
-    files = sorted(p.name for p in dl.dirname.iterdir())
-    assert files == ['0001.jpg', '0002.jpg', '0003.jpg']
+    _register_jpegs(mocked_http, ('0001', '0002', '0003'))
+    report = dl.run(n_workers=2, size=0, progress=_null_progress())
+    assert report.successful
+    assert _image_files(dl.dirname) == ['0001.jpg', '0002.jpg', '0003.jpg']

--- a/tests/test_download_run.py
+++ b/tests/test_download_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from pathlib import Path
 
@@ -46,7 +47,9 @@ def test_run_downloads_all_images_and_returns_consistent_report(mocked_http, dow
     assert report.expected == report.attempted == report.completed == 3
     assert report.bytes_written == 3 * len(TINY_JPEG)
     assert _image_files(downloader_in_tmp.dirname) == ['0001.jpg', '0002.jpg', '0003.jpg']
-    assert (downloader_in_tmp.dirname / '.antenati-index.json').is_file()
+    assert (downloader_in_tmp.dirname / '.antenati-manifest.json').is_file()
+    index = json.loads((downloader_in_tmp.dirname / '.antenati-index.json').read_text(encoding='utf-8'))
+    assert len(index['images']) == 3
 
 
 def test_run_uses_constrained_size_urls(mocked_http, downloader_in_tmp: Downloader) -> None:

--- a/tests/test_filename_planning.py
+++ b/tests/test_filename_planning.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from antenati.downloader import Downloader
+
+
+def _canvases(count: int) -> list[dict[str, object]]:
+    return [{'label': f'Pag. {index}'} for index in range(1, count + 1)]
+
+
+@pytest.mark.parametrize(
+    ('count', 'first', 'last'),
+    [
+        (9, 'pag-1', 'pag-9'),
+        (15, 'pag-01', 'pag-15'),
+        (150, 'pag-001', 'pag-150'),
+        (1200, 'pag-0001', 'pag-1200'),
+    ],
+)
+def test_numeric_labels_are_padded_to_gallery_width(count: int, first: str, last: str) -> None:
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+    stems = downloader._build_unique_stems(_canvases(count))
+    assert stems[0] == first
+    assert stems[-1] == last
+    assert stems == sorted(stems)
+
+
+def test_partial_range_reuses_full_gallery_stems() -> None:
+    downloader = Downloader('https://example.invalid/manifest', 6, 12)
+    stems = downloader._build_unique_stems(_canvases(150))
+    assert stems[6:12] == ['pag-007', 'pag-008', 'pag-009', 'pag-010', 'pag-011', 'pag-012']
+
+
+def test_non_numeric_labels_are_preserved_and_collisions_stay_deterministic() -> None:
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+    canvases = [{'label': 'Frontespizio'}, {'label': 'Frontespizio'}, {'label': ''}]
+    assert downloader._build_unique_stems(canvases) == ['frontespizio', 'frontespizio-2', 'image-3']

--- a/tests/test_functional_offline.py
+++ b/tests/test_functional_offline.py
@@ -1,0 +1,300 @@
+"""Offline functional tests using a real local HTTP server.
+
+Unlike the ``responses``-based tests, these cases exercise the actual Requests
+socket/streaming path, filesystem writes and selected CLI flows without
+contacting the Portale Antenati.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from antenati import Downloader, ProgressBar
+from antenati.output import ExistingPolicy, prepare_output, run_with_policy
+from tests.conftest import TINY_JPEG
+
+
+@dataclass
+class _ServerState:
+    base_url: str = ''
+    pages: int = 15
+    requests: Counter[str] = field(default_factory=Counter)
+    corrupt_pages: set[int] = field(default_factory=set)
+
+    @property
+    def manifest_url(self) -> str:
+        return f'{self.base_url}/manifest'
+
+    @property
+    def gallery_url(self) -> str:
+        return f'{self.base_url}/ark:/12657/an_ua19944535/gallery'
+
+    def manifest(self) -> dict:
+        canvases = []
+        for page in range(1, self.pages + 1):
+            canvases.append(
+                {
+                    '@id': f'{self.base_url}/ark:/12657/an_ua19944535/canvas/p{page}',
+                    '@type': 'sc:Canvas',
+                    'label': f'Pag. {page}',
+                    'images': [
+                        {
+                            '@type': 'oa:Annotation',
+                            'resource': {
+                                '@id': f'{self.base_url}/iiif/img{page}/full/max/0/default.jpg',
+                                '@type': 'dctypes:Image',
+                                'format': 'image/jpeg',
+                            },
+                        }
+                    ],
+                }
+            )
+        return {
+            '@context': 'http://iiif.io/api/presentation/2/context.json',
+            '@id': self.manifest_url,
+            '@type': 'sc:Manifest',
+            'label': 'Offline functional gallery',
+            'metadata': [
+                {'label': 'Contesto archivistico', 'value': 'Functional tests/Comune di Esempio'},
+                {'label': 'Titolo', 'value': '1900'},
+                {'label': 'Tipologia', 'value': 'Nati'},
+            ],
+            'sequences': [{'@type': 'sc:Sequence', 'canvases': canvases}],
+        }
+
+    @property
+    def image_requests(self) -> int:
+        return sum(count for path, count in self.requests.items() if path.startswith('/iiif/'))
+
+    def reset_requests(self) -> None:
+        self.requests.clear()
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _FunctionalServer
+
+    def do_GET(self) -> None:
+        state = self.server.state
+        state.requests[self.path] += 1
+        if self.path == '/manifest':
+            self._send('application/json; charset=utf-8', json.dumps(state.manifest()).encode())
+            return
+        if self.path == '/ark:/12657/an_ua19944535/gallery':
+            body = f'<script>const manifestId = "{state.manifest_url}";</script>'.encode()
+            self._send('text/html; charset=utf-8', body)
+            return
+        if self.path.startswith('/iiif/img') and self.path.endswith('/0/default.jpg'):
+            page = int(self.path.split('/')[2].removeprefix('img'))
+            payload = b'not-a-jpeg' if page in state.corrupt_pages else TINY_JPEG
+            self._send('image/jpeg', payload)
+            return
+        self.send_error(404)
+
+    def _send(self, content_type: str, body: bytes) -> None:
+        self.send_response(200)
+        self.send_header('Content-Type', content_type)
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+class _FunctionalServer(ThreadingHTTPServer):
+    state: _ServerState
+
+
+@contextmanager
+def _fake_iiif_server() -> Iterator[_ServerState]:
+    state = _ServerState()
+    server = _FunctionalServer(('127.0.0.1', 0), _Handler)
+    state.base_url = f'http://127.0.0.1:{server.server_port}'
+    server.state = state
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _total: None, update=lambda: None)
+
+
+def _run(state: _ServerState, output: Path, *, size: int = 0, policy: ExistingPolicy = ExistingPolicy.OVERWRITE):
+    downloader = Downloader(state.manifest_url, first=0, last=None)
+    downloader.load()
+    prepare_output(downloader, output, policy)
+    return run_with_policy(downloader, n_workers=3, size=size, progress=_progress(), policy=policy)
+
+
+def _image_names(output: Path) -> list[str]:
+    return sorted(path.name for path in output.glob('*.jpg'))
+
+
+def _cli(*args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, '-m', 'antenati.cli', *args],
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_real_http_full_download_writes_images_and_provenance(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        report = _run(state, output)
+
+        assert report.successful
+        assert report.expected == report.completed == 15
+        assert state.image_requests == 15
+        assert _image_names(output) == [f'pag-{page:02d}.jpg' for page in range(1, 16)]
+        assert (output / '.antenati-manifest.json').is_file()
+        index = json.loads((output / '.antenati-index.json').read_text(encoding='utf-8'))
+        assert len(index['images']) == 15
+
+
+def test_real_http_gallery_html_to_manifest_to_images(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        downloader = Downloader(state.gallery_url, first=0, last=2)
+        downloader.load()
+        prepare_output(downloader, output, ExistingPolicy.OVERWRITE)
+        report = run_with_policy(downloader, n_workers=2, size=0, progress=_progress(), policy=ExistingPolicy.OVERWRITE)
+
+        assert report.successful
+        assert _image_names(output) == ['pag-01.jpg', 'pag-02.jpg']
+        assert state.requests['/ark:/12657/an_ua19944535/gallery'] == 1
+        assert state.requests['/manifest'] == 1
+        assert state.image_requests == 2
+
+
+def test_real_http_resume_makes_no_image_requests_when_everything_is_valid(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        _run(state, output)
+        state.reset_requests()
+
+        report = _run(state, output, policy=ExistingPolicy.RESUME)
+
+        assert report.successful
+        assert report.completed == 0
+        assert report.skipped == 15
+        assert state.image_requests == 0
+
+
+def test_real_http_resume_redownloads_only_missing_file(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        _run(state, output)
+        (output / 'pag-07.jpg').unlink()
+        state.reset_requests()
+
+        report = _run(state, output, policy=ExistingPolicy.RESUME)
+
+        assert report.successful
+        assert report.completed == 1
+        assert report.skipped == 14
+        assert state.image_requests == 1
+        assert (output / 'pag-07.jpg').read_bytes() == TINY_JPEG
+
+
+def test_real_http_resume_redownloads_only_hash_mismatched_file(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        _run(state, output)
+        (output / 'pag-08.jpg').write_bytes(b'corrupt-local-file')
+        state.reset_requests()
+
+        report = _run(state, output, policy=ExistingPolicy.RESUME)
+
+        assert report.successful
+        assert report.completed == 1
+        assert report.skipped == 14
+        assert state.image_requests == 1
+        assert (output / 'pag-08.jpg').read_bytes() == TINY_JPEG
+
+
+def test_real_http_resume_redownloads_all_when_requested_size_changes(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        _run(state, output, size=0)
+        state.reset_requests()
+
+        report = _run(state, output, size=200, policy=ExistingPolicy.RESUME)
+
+        assert report.successful
+        assert report.completed == 15
+        assert report.skipped == 0
+        assert state.image_requests == 15
+        assert any('/!200,200/' in path for path in state.requests)
+
+
+def test_real_http_corrupt_remote_image_is_not_committed(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        state.corrupt_pages.add(4)
+        output = tmp_path / 'archive'
+        report = _run(state, output)
+
+        assert not report.successful
+        assert report.completed == 14
+        assert len(report.failed) == 1
+        assert not (output / 'pag-04.jpg').exists()
+        assert not list(output.glob('*.tmp'))
+
+
+def test_cli_dry_run_uses_real_http_but_downloads_no_images(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        result = _cli(state.manifest_url, '--output', str(output), '--dry-run')
+
+        assert result.returncode == 0, result.stderr
+        assert 'pag-01.jpg' in result.stdout
+        assert 'pag-15.jpg' in result.stdout
+        assert state.image_requests == 0
+        assert not output.exists()
+
+
+def test_cli_default_ask_can_resume_existing_real_download(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        first = _cli(state.manifest_url, '--output', str(output), '--existing', 'overwrite')
+        assert first.returncode == 0, first.stderr
+        state.reset_requests()
+
+        resumed = _cli(state.manifest_url, '--output', str(output), input_text='resume\n')
+
+        assert resumed.returncode == 0, resumed.stderr
+        assert 'Choose how to handle existing files' in resumed.stdout
+        assert 'skipped: 15' in resumed.stdout
+        assert state.image_requests == 0
+
+
+def test_cli_explicit_error_policy_fails_cleanly_on_existing_output(tmp_path: Path) -> None:
+    with _fake_iiif_server() as state:
+        output = tmp_path / 'archive'
+        first = _cli(state.manifest_url, '--output', str(output), '--existing', 'overwrite')
+        assert first.returncode == 0, first.stderr
+        state.reset_requests()
+
+        second = _cli(state.manifest_url, '--output', str(output), '--existing', 'error')
+
+        assert second.returncode != 0
+        assert 'already exists and is not empty' in second.stderr
+        assert state.image_requests == 0

--- a/tests/test_functional_offline.py
+++ b/tests/test_functional_offline.py
@@ -1,141 +1,49 @@
-"""Offline functional tests using a real local HTTP server.
+"""Offline functional tests built on the shared mocked HTTP fixtures.
 
-Unlike the ``responses``-based tests, these cases exercise the actual Requests
-socket/streaming path, filesystem writes and selected CLI flows without
-contacting the Portale Antenati.
+These tests keep CLI parsing, downloader orchestration, filesystem writes,
+provenance and resume behavior real while mocking only external HTTP traffic.
+Live compatibility with the Portale Antenati remains covered separately by the
+opt-in integration canaries.
 """
 
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
-import threading
-from collections import Counter
-from collections.abc import Iterator
-from contextlib import contextmanager
-from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+import pytest
+import responses
+
 from antenati import Downloader, ProgressBar
+from antenati import cli as antenati_cli
 from antenati.output import ExistingPolicy, prepare_output, run_with_policy
-from tests.conftest import TINY_JPEG
+from tests.conftest import MANIFEST_URL, TINY_JPEG
 
-
-@dataclass
-class _ServerState:
-    base_url: str = ''
-    pages: int = 15
-    requests: Counter[str] = field(default_factory=Counter)
-    corrupt_pages: set[int] = field(default_factory=set)
-
-    @property
-    def manifest_url(self) -> str:
-        return f'{self.base_url}/manifest'
-
-    @property
-    def gallery_url(self) -> str:
-        return f'{self.base_url}/ark:/12657/an_ua19944535/gallery'
-
-    def manifest(self) -> dict:
-        canvases = []
-        for page in range(1, self.pages + 1):
-            canvases.append(
-                {
-                    '@id': f'{self.base_url}/ark:/12657/an_ua19944535/canvas/p{page}',
-                    '@type': 'sc:Canvas',
-                    'label': f'Pag. {page}',
-                    'images': [
-                        {
-                            '@type': 'oa:Annotation',
-                            'resource': {
-                                '@id': f'{self.base_url}/iiif/img{page}/full/max/0/default.jpg',
-                                '@type': 'dctypes:Image',
-                                'format': 'image/jpeg',
-                            },
-                        }
-                    ],
-                }
-            )
-        return {
-            '@context': 'http://iiif.io/api/presentation/2/context.json',
-            '@id': self.manifest_url,
-            '@type': 'sc:Manifest',
-            'label': 'Offline functional gallery',
-            'metadata': [
-                {'label': 'Contesto archivistico', 'value': 'Functional tests/Comune di Esempio'},
-                {'label': 'Titolo', 'value': '1900'},
-                {'label': 'Tipologia', 'value': 'Nati'},
-            ],
-            'sequences': [{'@type': 'sc:Sequence', 'canvases': canvases}],
-        }
-
-    @property
-    def image_requests(self) -> int:
-        return sum(count for path, count in self.requests.items() if path.startswith('/iiif/'))
-
-    def reset_requests(self) -> None:
-        self.requests.clear()
-
-
-class _Handler(BaseHTTPRequestHandler):
-    server: _FunctionalServer
-
-    def do_GET(self) -> None:
-        state = self.server.state
-        state.requests[self.path] += 1
-        if self.path == '/manifest':
-            self._send('application/json; charset=utf-8', json.dumps(state.manifest()).encode())
-            return
-        if self.path == '/ark:/12657/an_ua19944535/gallery':
-            body = f'<script>const manifestId = "{state.manifest_url}";</script>'.encode()
-            self._send('text/html; charset=utf-8', body)
-            return
-        if self.path.startswith('/iiif/img') and self.path.endswith('/0/default.jpg'):
-            page = int(self.path.split('/')[2].removeprefix('img'))
-            payload = b'not-a-jpeg' if page in state.corrupt_pages else TINY_JPEG
-            self._send('image/jpeg', payload)
-            return
-        self.send_error(404)
-
-    def _send(self, content_type: str, body: bytes) -> None:
-        self.send_response(200)
-        self.send_header('Content-Type', content_type)
-        self.send_header('Content-Length', str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, _format: str, *_args: object) -> None:
-        return
-
-
-class _FunctionalServer(ThreadingHTTPServer):
-    state: _ServerState
-
-
-@contextmanager
-def _fake_iiif_server() -> Iterator[_ServerState]:
-    state = _ServerState()
-    server = _FunctionalServer(('127.0.0.1', 0), _Handler)
-    state.base_url = f'http://127.0.0.1:{server.server_port}'
-    server.state = state
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield state
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join(timeout=5)
+_LABELS = ('0001', '0002', '0003')
+_IMAGE_PREFIX = 'https://iiif.example.org/iiif/img'
 
 
 def _progress() -> ProgressBar:
     return ProgressBar(set_total=lambda _total: None, update=lambda: None)
 
 
-def _run(state: _ServerState, output: Path, *, size: int = 0, policy: ExistingPolicy = ExistingPolicy.OVERWRITE):
-    downloader = Downloader(state.manifest_url, first=0, last=None)
+def _image_url(label: str, size: int = 0) -> str:
+    size_part = f'!{size},{size}' if size > 0 else 'pct:100'
+    return f'{_IMAGE_PREFIX}{label[-1]}/full/{size_part}/0/default.jpg'
+
+
+def _register_jpegs(mocked_http, *, size: int = 0, corrupt_label: str | None = None) -> None:
+    for label in _LABELS:
+        payload = b'not-a-jpeg' if label == corrupt_label else TINY_JPEG
+        mocked_http.add(responses.GET, _image_url(label, size), body=payload, status=200, content_type='image/jpeg')
+
+
+def _image_request_count(mocked_http) -> int:
+    return sum(1 for call in mocked_http.calls if str(call.request.url).startswith(_IMAGE_PREFIX))
+
+
+def _run(source_url: str, output: Path, *, size: int = 0, policy: ExistingPolicy = ExistingPolicy.OVERWRITE):
+    downloader = Downloader(source_url, first=0, last=None)
     downloader.load()
     prepare_output(downloader, output, policy)
     return run_with_policy(downloader, n_workers=3, size=size, progress=_progress(), policy=policy)
@@ -145,156 +53,102 @@ def _image_names(output: Path) -> list[str]:
     return sorted(path.name for path in output.glob('*.jpg'))
 
 
-def _cli(*args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [sys.executable, '-m', 'antenati.cli', *args],
-        input=input_text,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=30,
-    )
+def _invoke_cli(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], *args: str) -> tuple[int, str, str]:
+    monkeypatch.setattr(sys, 'argv', ['antenati', *args])
+    try:
+        antenati_cli.main()
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    else:
+        code = 0
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
 
 
-def test_real_http_full_download_writes_images_and_provenance(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        report = _run(state, output)
+def test_resume_redownloads_only_missing_file(mocked_http, tmp_path: Path) -> None:
+    _register_jpegs(mocked_http)
+    output = tmp_path / 'archive'
+    _run(MANIFEST_URL, output)
+    (output / '0002.jpg').unlink()
+    image_calls_before = _image_request_count(mocked_http)
 
-        assert report.successful
-        assert report.expected == report.completed == 15
-        assert state.image_requests == 15
-        assert _image_names(output) == [f'pag-{page:02d}.jpg' for page in range(1, 16)]
-        assert (output / '.antenati-manifest.json').is_file()
-        index = json.loads((output / '.antenati-index.json').read_text(encoding='utf-8'))
-        assert len(index['images']) == 15
+    report = _run(MANIFEST_URL, output, policy=ExistingPolicy.RESUME)
 
-
-def test_real_http_gallery_html_to_manifest_to_images(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        downloader = Downloader(state.gallery_url, first=0, last=2)
-        downloader.load()
-        prepare_output(downloader, output, ExistingPolicy.OVERWRITE)
-        report = run_with_policy(downloader, n_workers=2, size=0, progress=_progress(), policy=ExistingPolicy.OVERWRITE)
-
-        assert report.successful
-        assert _image_names(output) == ['pag-01.jpg', 'pag-02.jpg']
-        assert state.requests['/ark:/12657/an_ua19944535/gallery'] == 1
-        assert state.requests['/manifest'] == 1
-        assert state.image_requests == 2
+    assert report.successful
+    assert report.completed == 1
+    assert report.skipped == 2
+    assert _image_request_count(mocked_http) == image_calls_before + 1
+    assert (output / '0002.jpg').read_bytes() == TINY_JPEG
 
 
-def test_real_http_resume_makes_no_image_requests_when_everything_is_valid(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        _run(state, output)
-        state.reset_requests()
+def test_corrupt_remote_image_is_not_committed(mocked_http, tmp_path: Path) -> None:
+    _register_jpegs(mocked_http, corrupt_label='0002')
+    output = tmp_path / 'archive'
 
-        report = _run(state, output, policy=ExistingPolicy.RESUME)
+    report = _run(MANIFEST_URL, output)
 
-        assert report.successful
-        assert report.completed == 0
-        assert report.skipped == 15
-        assert state.image_requests == 0
-
-
-def test_real_http_resume_redownloads_only_missing_file(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        _run(state, output)
-        (output / 'pag-07.jpg').unlink()
-        state.reset_requests()
-
-        report = _run(state, output, policy=ExistingPolicy.RESUME)
-
-        assert report.successful
-        assert report.completed == 1
-        assert report.skipped == 14
-        assert state.image_requests == 1
-        assert (output / 'pag-07.jpg').read_bytes() == TINY_JPEG
+    assert not report.successful
+    assert report.completed == 2
+    assert len(report.failed) == 1
+    assert not (output / '0002.jpg').exists()
+    assert not list(output.glob('*.tmp'))
 
 
-def test_real_http_resume_redownloads_only_hash_mismatched_file(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        _run(state, output)
-        (output / 'pag-08.jpg').write_bytes(b'corrupt-local-file')
-        state.reset_requests()
+def test_cli_dry_run_downloads_no_images(
+    mocked_http,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _register_jpegs(mocked_http)
+    output = tmp_path / 'archive'
+    image_calls_before = _image_request_count(mocked_http)
 
-        report = _run(state, output, policy=ExistingPolicy.RESUME)
+    code, stdout, stderr = _invoke_cli(monkeypatch, capsys, MANIFEST_URL, '--output', str(output), '--dry-run')
 
-        assert report.successful
-        assert report.completed == 1
-        assert report.skipped == 14
-        assert state.image_requests == 1
-        assert (output / 'pag-08.jpg').read_bytes() == TINY_JPEG
-
-
-def test_real_http_resume_redownloads_all_when_requested_size_changes(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        _run(state, output, size=0)
-        state.reset_requests()
-
-        report = _run(state, output, size=200, policy=ExistingPolicy.RESUME)
-
-        assert report.successful
-        assert report.completed == 15
-        assert report.skipped == 0
-        assert state.image_requests == 15
-        assert any('/!200,200/' in path for path in state.requests)
+    assert code == 0, stderr
+    assert '0001.jpg' in stdout
+    assert '0003.jpg' in stdout
+    assert _image_request_count(mocked_http) == image_calls_before
+    assert not output.exists()
 
 
-def test_real_http_corrupt_remote_image_is_not_committed(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        state.corrupt_pages.add(4)
-        output = tmp_path / 'archive'
-        report = _run(state, output)
+def test_cli_default_ask_can_resume_existing_download(
+    mocked_http,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _register_jpegs(mocked_http)
+    output = tmp_path / 'archive'
+    first_code, _, first_stderr = _invoke_cli(monkeypatch, capsys, MANIFEST_URL, '--output', str(output), '--existing', 'overwrite')
+    assert first_code == 0, first_stderr
+    image_calls_before = _image_request_count(mocked_http)
+    monkeypatch.setattr(antenati_cli.click, 'prompt', lambda *_args, **_kwargs: 'resume')
 
-        assert not report.successful
-        assert report.completed == 14
-        assert len(report.failed) == 1
-        assert not (output / 'pag-04.jpg').exists()
-        assert not list(output.glob('*.tmp'))
+    resumed_code, resumed_stdout, resumed_stderr = _invoke_cli(monkeypatch, capsys, MANIFEST_URL, '--output', str(output))
 
-
-def test_cli_dry_run_uses_real_http_but_downloads_no_images(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        result = _cli(state.manifest_url, '--output', str(output), '--dry-run')
-
-        assert result.returncode == 0, result.stderr
-        assert 'pag-01.jpg' in result.stdout
-        assert 'pag-15.jpg' in result.stdout
-        assert state.image_requests == 0
-        assert not output.exists()
+    assert resumed_code == 0, resumed_stderr
+    assert 'Choose how to handle existing files' in resumed_stdout
+    assert 'skipped: 3' in resumed_stdout
+    assert _image_request_count(mocked_http) == image_calls_before
 
 
-def test_cli_default_ask_can_resume_existing_real_download(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        first = _cli(state.manifest_url, '--output', str(output), '--existing', 'overwrite')
-        assert first.returncode == 0, first.stderr
-        state.reset_requests()
+def test_cli_explicit_error_policy_rejects_existing_output_without_image_requests(
+    mocked_http,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    _register_jpegs(mocked_http)
+    output = tmp_path / 'archive'
+    first_code, _, first_stderr = _invoke_cli(monkeypatch, capsys, MANIFEST_URL, '--output', str(output), '--existing', 'overwrite')
+    assert first_code == 0, first_stderr
+    image_calls_before = _image_request_count(mocked_http)
+    monkeypatch.setattr(sys, 'argv', ['antenati', MANIFEST_URL, '--output', str(output), '--existing', 'error'])
 
-        resumed = _cli(state.manifest_url, '--output', str(output), input_text='resume\n')
+    with pytest.raises(RuntimeError, match='already exists and is not empty'):
+        antenati_cli.main()
 
-        assert resumed.returncode == 0, resumed.stderr
-        assert 'Choose how to handle existing files' in resumed.stdout
-        assert 'skipped: 15' in resumed.stdout
-        assert state.image_requests == 0
-
-
-def test_cli_explicit_error_policy_fails_cleanly_on_existing_output(tmp_path: Path) -> None:
-    with _fake_iiif_server() as state:
-        output = tmp_path / 'archive'
-        first = _cli(state.manifest_url, '--output', str(output), '--existing', 'overwrite')
-        assert first.returncode == 0, first.stderr
-        state.reset_requests()
-
-        second = _cli(state.manifest_url, '--output', str(output), '--existing', 'error')
-
-        assert second.returncode != 0
-        assert 'already exists and is not empty' in second.stderr
-        assert state.image_requests == 0
+    capsys.readouterr()
+    assert _image_request_count(mocked_http) == image_calls_before

--- a/tests/test_gui_worker.py
+++ b/tests/test_gui_worker.py
@@ -1,11 +1,4 @@
-"""Unit tests for :mod:`antenati.gui.worker`.
-
-These tests stay completely Tk-free: they exercise the worker thread by
-injecting fake :class:`Downloader` objects and asserting the sequence of
-events that lands on the worker's queue. The real GUI just polls that
-queue, so getting these events right is enough to guarantee the UI
-behaves correctly.
-"""
+"""Tk-free unit tests for the GUI worker state machine."""
 
 from __future__ import annotations
 
@@ -15,148 +8,109 @@ from typing import Any
 
 import pytest
 
-from antenati.downloader import ProgressBar
-from antenati.gui.worker import (
-    Cancelled,
-    Done,
-    DownloadParams,
-    DownloadWorker,
-    Failed,
-    Progress,
-    Tick,
-)
+from antenati.downloader import DownloadReport, ProgressBar
+from antenati.gui.worker import Cancelled, Done, DownloadParams, DownloadWorker, Failed, Progress, Tick
 
 
 class _FakeDownloader:
-    """Minimal Downloader stand-in: pumps a fixed number of ticks and ends."""
-
-    def __init__(
-        self,
-        n_canvases: int = 3,
-        total_bytes: int = 42,
-        raise_in_run: Exception | None = None,
-        cancel_after: int | None = None,
-    ) -> None:
-        self.gallery_length = n_canvases
+    def __init__(self, n_canvases: int = 3, total_bytes: int = 42, raise_in_run: Exception | None = None, block_for_cancel: bool = False) -> None:
         self.dirname = Path('ignored')
         self._n_canvases = n_canvases
         self._total_bytes = total_bytes
         self._raise = raise_in_run
-        self._cancel_after = cancel_after
-        self.check_dir_called_with: tuple[str, bool] | None = None
+        self._block_for_cancel = block_for_cancel
+        self.loaded = False
 
-    def check_dir(self, parent_dir: str, interactive: bool) -> None:
-        self.check_dir_called_with = (parent_dir, interactive)
+    def load(self):
+        self.loaded = True
+        return self
 
-    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel=None) -> int:
+    def run(self, n_workers: int, size: int, progress: ProgressBar, cancel=None, *, resume: bool = False) -> DownloadReport:
+        del n_workers, size, resume
         if self._raise is not None:
             raise self._raise
         progress.set_total(self._n_canvases)
-        if self._cancel_after is not None and cancel is not None:
-            for _ in range(self._cancel_after):
-                progress.update()
-            # Block until the test calls worker.cancel(); mirrors the
-            # real Downloader's "stop at next canvas boundary" behaviour.
+        if self._block_for_cancel and cancel is not None:
             cancel.wait(timeout=2.0)
-            return self._total_bytes // 2
+            return DownloadReport(self._n_canvases, 0, 0, 0, (), True, 0)
         for _ in range(self._n_canvases):
             progress.update()
-        return self._total_bytes
+        return DownloadReport(self._n_canvases, self._n_canvases, self._n_canvases, 0, (), False, self._total_bytes)
 
 
 def _drain_events(worker: DownloadWorker, timeout: float = 2.0) -> list[Any]:
-    """Collect all events the worker pushes until the thread finishes."""
     worker.join(timeout=timeout)
     events: list[Any] = []
     try:
         while True:
             events.append(worker.events.get_nowait())
     except queue.Empty:
-        pass
-    return events
+        return events
 
 
-def _params() -> DownloadParams:
-    return DownloadParams(
-        url='https://example.org/gallery',
-        parent_dir='/tmp/x',
-        size=0,
-        first=0,
-        last=None,
-    )
+def _params(tmp_path: Path) -> DownloadParams:
+    return DownloadParams(url='https://example.org/gallery', output_dir=str(tmp_path / 'out'), size=0, first=0, last=None)
 
 
-def test_happy_path_emits_progress_ticks_and_done() -> None:
+def test_happy_path_emits_progress_ticks_and_done(tmp_path: Path) -> None:
     fake = _FakeDownloader(n_canvases=3, total_bytes=12345)
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
-    worker.start(_params())
+    worker = DownloadWorker(factory=lambda url, first, last, descriptive_names=False: fake)
+    worker.start(_params(tmp_path))
     events = _drain_events(worker)
-
     assert isinstance(events[0], Progress)
     assert events[0].total == 3
-    assert sum(1 for e in events if isinstance(e, Tick)) == 3
+    assert sum(isinstance(event, Tick) for event in events) == 3
     assert isinstance(events[-1], Done)
-    assert events[-1].total_bytes == 12345
+    assert events[-1].report.bytes_written == 12345
+    assert fake.loaded
 
 
-def test_check_dir_is_called_with_parent_and_non_interactive() -> None:
-    fake = _FakeDownloader(n_canvases=1)
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
-    worker.start(_params())
-    _drain_events(worker)
-    assert fake.check_dir_called_with == ('/tmp/x', False)
-
-
-def test_constructor_failure_emits_failed_event() -> None:
-    def boom(url: str, first: int, last: int | None):
+def test_constructor_failure_emits_failed_event(tmp_path: Path) -> None:
+    def boom(url: str, first: int, last: int | None, descriptive_names: bool = False):
+        del url, first, last, descriptive_names
         raise RuntimeError('manifest blew up')
 
     worker = DownloadWorker(factory=boom)
-    worker.start(_params())
+    worker.start(_params(tmp_path))
     events = _drain_events(worker)
     assert len(events) == 1
     assert isinstance(events[0], Failed)
     assert 'manifest blew up' in events[0].message
 
 
-def test_run_failure_emits_failed_event() -> None:
+def test_run_failure_emits_failed_event(tmp_path: Path) -> None:
     fake = _FakeDownloader(raise_in_run=RuntimeError('disk full'))
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
-    worker.start(_params())
-    events = _drain_events(worker)
-    failures = [e for e in events if isinstance(e, Failed)]
+    worker = DownloadWorker(factory=lambda url, first, last, descriptive_names=False: fake)
+    worker.start(_params(tmp_path))
+    failures = [event for event in _drain_events(worker) if isinstance(event, Failed)]
     assert len(failures) == 1
     assert 'disk full' in failures[0].message
 
 
-def test_cancel_before_completion_emits_cancelled_event() -> None:
-    # Have the fake check the cancel event and return early.
-    fake = _FakeDownloader(n_canvases=10, cancel_after=2)
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
-    worker.start(_params())
+def test_cancel_before_completion_emits_cancelled_event(tmp_path: Path) -> None:
+    fake = _FakeDownloader(n_canvases=10, block_for_cancel=True)
+    worker = DownloadWorker(factory=lambda url, first, last, descriptive_names=False: fake)
+    worker.start(_params(tmp_path))
     worker.cancel()
     events = _drain_events(worker)
-    assert any(isinstance(e, Cancelled) for e in events)
-    assert not any(isinstance(e, Done) for e in events)
+    assert any(isinstance(event, Cancelled) for event in events)
+    assert not any(isinstance(event, Done) for event in events)
 
 
-def test_starting_twice_while_running_raises() -> None:
-    # cancel_after=0 + factory returns a fake that blocks on cancel.wait()
-    # gives us a worker that's guaranteed to be alive when start() is
-    # called a second time.
-    fake = _FakeDownloader(n_canvases=1, cancel_after=0)
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
-    worker.start(_params())
+def test_starting_twice_while_running_raises(tmp_path: Path) -> None:
+    fake = _FakeDownloader(block_for_cancel=True)
+    worker = DownloadWorker(factory=lambda url, first, last, descriptive_names=False: fake)
+    worker.start(_params(tmp_path))
     with pytest.raises(RuntimeError, match='already in progress'):
-        worker.start(_params())
+        worker.start(_params(tmp_path))
     worker.cancel()
     _drain_events(worker)
 
 
-def test_is_running_flips_around_the_thread_lifetime() -> None:
+def test_is_running_flips_around_thread_lifetime(tmp_path: Path) -> None:
     fake = _FakeDownloader(n_canvases=1)
-    worker = DownloadWorker(factory=lambda url, first, last: fake)
+    worker = DownloadWorker(factory=lambda url, first, last, descriptive_names=False: fake)
     assert worker.is_running() is False
-    worker.start(_params())
+    worker.start(_params(tmp_path))
     worker.join(timeout=2.0)
     assert worker.is_running() is False

--- a/tests/test_gui_worker.py
+++ b/tests/test_gui_worker.py
@@ -10,6 +10,7 @@ import pytest
 
 from antenati.downloader import DownloadReport, ProgressBar
 from antenati.gui.worker import Cancelled, Done, DownloadParams, DownloadWorker, Failed, Progress, Tick
+from antenati.output import ExistingPolicy
 
 
 class _FakeDownloader:
@@ -49,7 +50,14 @@ def _drain_events(worker: DownloadWorker, timeout: float = 2.0) -> list[Any]:
 
 
 def _params(tmp_path: Path) -> DownloadParams:
-    return DownloadParams(url='https://example.org/gallery', output_dir=str(tmp_path / 'out'), size=0, first=0, last=None)
+    return DownloadParams(
+        url='https://example.org/gallery',
+        output_dir=str(tmp_path / 'out'),
+        size=0,
+        first=0,
+        last=None,
+        existing_policy=ExistingPolicy.OVERWRITE,
+    )
 
 
 def test_happy_path_emits_progress_ticks_and_done(tmp_path: Path) -> None:

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,4 +1,4 @@
-"""Regression tests for correctness and hardening fixes introduced in v6.2."""
+"""Regression tests for correctness and hardening invariants."""
 
 from __future__ import annotations
 
@@ -13,8 +13,9 @@ def _null_progress() -> ProgressBar:
 
 
 def test_duplicate_canvas_labels_receive_unique_stems(downloader: Downloader) -> None:
-    downloader.canvases[1]['label'] = downloader.canvases[0]['label']
-    stems = downloader._Downloader__build_unique_stems()
+    canvases = list(downloader.canvases)
+    canvases[1]['label'] = canvases[0]['label']
+    stems = downloader._build_unique_stems(canvases)
     assert len(stems) == len(set(stems))
     assert stems[0] == '0001'
     assert stems[1] == '0001-2'
@@ -26,7 +27,10 @@ def test_preset_cancel_performs_no_additional_http_requests(mocked_http, downloa
     cancel = threading.Event()
     cancel.set()
 
-    assert downloader.run(n_workers=2, size=0, progress=_null_progress(), cancel=cancel) == 0
+    report = downloader.run(n_workers=2, size=0, progress=_null_progress(), cancel=cancel)
+    assert report.cancelled
+    assert report.attempted == 0
+    assert report.bytes_written == 0
     assert len(mocked_http.calls) == requests_before_run
     assert list(downloader.dirname.iterdir()) == []
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 import responses
+from requests import Response
 
 from antenati import http as antenati_http
 from antenati.errors import WafChallengeError
@@ -41,6 +44,21 @@ def test_fetch_raises_on_http_error() -> None:
         )
         with pytest.raises(Exception):  # noqa: B017 - requests.HTTPError subclass
             antenati_http.fetch(session, 'https://example.org/boom')
+
+
+def test_fetch_closes_response_on_http_error() -> None:
+    session = antenati_http.build_session()
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            'https://example.org/boom-stream',
+            body='nope',
+            status=500,
+            content_type='text/plain',
+        )
+        with patch.object(Response, 'close', autospec=True) as mock_close, pytest.raises(Exception):  # noqa: B017
+            antenati_http.fetch(session, 'https://example.org/boom-stream', stream=True)
+    assert mock_close.called
 
 
 def test_fetch_raises_on_waf_challenge() -> None:

--- a/tests/test_iiif_parsing.py
+++ b/tests/test_iiif_parsing.py
@@ -1,9 +1,4 @@
-"""Tests for the IIIF gallery parsing path.
-
-Exercises both the pure helpers in :mod:`antenati.iiif` /
-:mod:`antenati.http` and the orchestration in
-:class:`antenati.Downloader`.
-"""
+"""Tests for the IIIF gallery parsing path."""
 
 from __future__ import annotations
 
@@ -32,9 +27,9 @@ def test_archive_id_helper_raises_when_url_lacks_two_numbers() -> None:
         antenati_iiif.get_archive_id_from_url('https://antenati.cultura.gov.it/no-numbers/')
 
 
-def test_constructor_raises_when_url_lacks_two_numbers(mocked_http) -> None:
+def test_load_raises_when_url_lacks_archive_id(mocked_http) -> None:
     with pytest.raises(ManifestError, match='Cannot get archive ID'):
-        Downloader('https://antenati.cultura.gov.it/no-numbers/', 0, None)
+        Downloader('https://antenati.cultura.gov.it/no-numbers/', 0, None).load()
 
 
 def test_manifest_is_loaded_from_gallery_html(downloader: Downloader) -> None:
@@ -70,50 +65,32 @@ def test_parse_manifest_url_no_keyword_raises() -> None:
 @pytest.mark.parametrize(
     'html',
     [
-        # Single quotes around a URL with underscores and a query string.
         "<script>var manifestId = 'https://iiif.example.org/ark:/12657/an_ua19944535/manifest?v=2';</script>",
-        # Double quotes.
         '<script>var manifestId = "https://iiif.example.org/manifest";</script>',
     ],
 )
 def test_parse_manifest_url_accepts_modern_url_shapes(html: str) -> None:
-    # Locks the post-hardening behaviour: the legacy regex rejected
-    # underscores and query strings, the new one accepts them.
     result = antenati_iiif.parse_manifest_url_from_html(html, 'src')
     assert result.startswith('https://')
 
 
-def test_constructor_raises_when_html_lacks_manifest(gallery_html: str) -> None:
+def test_load_raises_when_html_lacks_manifest() -> None:
     bad_html = '<html><body>no manifest here</body></html>'
     with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            GALLERY_URL,
-            body=bad_html,
-            status=200,
-            content_type='text/html; charset=utf-8',
-        )
+        rsps.add(responses.GET, GALLERY_URL, body=bad_html, status=200, content_type='text/html; charset=utf-8')
         with pytest.raises(ManifestError, match='No IIIF manifest found'):
-            Downloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None).load()
 
 
-def test_constructor_raises_on_invalid_manifest_line() -> None:
-    # The ``manifestId`` keyword is present but there is no quoted URL on
-    # the line: parsing must raise a typed ManifestError.
+def test_load_raises_on_invalid_manifest_line() -> None:
     bad_html = '<script>var manifestId = noQuotesHere;</script>'
     with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            GALLERY_URL,
-            body=bad_html,
-            status=200,
-            content_type='text/html; charset=utf-8',
-        )
+        rsps.add(responses.GET, GALLERY_URL, body=bad_html, status=200, content_type='text/html; charset=utf-8')
         with pytest.raises(ManifestError, match='Invalid IIIF manifest line'):
-            Downloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None).load()
 
 
-def test_waf_challenge_is_detected() -> None:
+def test_waf_challenge_is_detected_during_load() -> None:
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
@@ -124,19 +101,13 @@ def test_waf_challenge_is_detected() -> None:
             content_type='text/html; charset=utf-8',
         )
         with pytest.raises(WafChallengeError, match='AWS WAF challenge'):
-            Downloader(GALLERY_URL, 0, None)
+            Downloader(GALLERY_URL, 0, None).load()
 
 
 def test_get_content_type_strips_parameters() -> None:
     session = Session()
     with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            'https://example.org/x',
-            body='ok',
-            status=200,
-            content_type='text/html; charset=utf-8',
-        )
+        rsps.add(responses.GET, 'https://example.org/x', body='ok', status=200, content_type='text/html; charset=utf-8')
         reply = session.get('https://example.org/x')
     assert antenati_http.get_content_type(reply) == 'text/html'
 
@@ -144,13 +115,7 @@ def test_get_content_type_strips_parameters() -> None:
 def test_get_content_charset() -> None:
     session = Session()
     with responses.RequestsMock() as rsps:
-        rsps.add(
-            responses.GET,
-            'https://example.org/x',
-            body='ok',
-            status=200,
-            content_type='application/json; charset=utf-8',
-        )
+        rsps.add(responses.GET, 'https://example.org/x', body='ok', status=200, content_type='application/json; charset=utf-8')
         reply = session.get('https://example.org/x')
     assert antenati_http.get_content_charset(reply) == 'utf-8'
 
@@ -199,10 +164,8 @@ def test_image_id_raises_on_short_path() -> None:
 
 
 def test_downloader_accepts_manifest_url_directly(mocked_http) -> None:
-    # The gallery page is never fetched: only the manifest URL is hit.
-    # This is the workaround for galleries behind the AWS WAF challenge
-    # (https://github.com/gcerretani/antenati/issues/25).
     dl = Downloader(MANIFEST_URL, first=0, last=None)
+    dl.load()
     assert dl.archive_id == ARCHIVE_ID
     assert dl.gallery_length == 3
     requested = [call.request.url for call in mocked_http.calls]

--- a/tests/test_image_validation.py
+++ b/tests/test_image_validation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from antenati.errors import ImageValidationError
+from antenati.image import validate_image_bytes
+from tests.conftest import TINY_JPEG
+
+
+def test_html_200_payload_is_rejected() -> None:
+    with pytest.raises(ImageValidationError, match='Unsupported image media type'):
+        validate_image_bytes('text/html', b'<html>blocked</html>')
+
+
+def test_corrupt_jpeg_payload_is_rejected() -> None:
+    with pytest.raises(ImageValidationError, match='Invalid or corrupt'):
+        validate_image_bytes('image/jpeg', b'not-a-jpeg')
+
+
+def test_mime_signature_mismatch_is_rejected() -> None:
+    png = b'\x89PNG\r\n\x1a\n' + b'payload'
+    with pytest.raises(ImageValidationError, match='media type mismatch'):
+        validate_image_bytes('image/jpeg', png)
+
+
+def test_valid_supported_jpeg_is_accepted() -> None:
+    assert validate_image_bytes('image/jpeg', TINY_JPEG) == '.jpg'

--- a/tests/test_output_policy.py
+++ b/tests/test_output_policy.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from antenati import Downloader
+from antenati.output import ExistingPolicy, prepare_output
+
+
+def test_error_policy_rejects_nonempty_explicit_output(tmp_path: Path) -> None:
+    output = tmp_path / 'archive'
+    output.mkdir()
+    (output / 'existing.jpg').write_bytes(b'existing')
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+
+    with pytest.raises(RuntimeError, match='already exists and is not empty'):
+        prepare_output(downloader, output, ExistingPolicy.ERROR)
+
+
+def test_overwrite_policy_accepts_existing_output_without_deleting_it(tmp_path: Path) -> None:
+    output = tmp_path / 'archive'
+    output.mkdir()
+    existing = output / 'existing.jpg'
+    existing.write_bytes(b'existing')
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+
+    assert prepare_output(downloader, output, ExistingPolicy.OVERWRITE) == output
+    assert existing.read_bytes() == b'existing'
+
+
+def test_prepare_output_creates_exact_requested_directory(tmp_path: Path) -> None:
+    output = tmp_path / 'chosen-name'
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+
+    assert prepare_output(downloader, output, ExistingPolicy.ERROR) == output
+    assert output.is_dir()

--- a/tests/test_output_policy.py
+++ b/tests/test_output_policy.py
@@ -5,7 +5,38 @@ from pathlib import Path
 import pytest
 
 from antenati import Downloader
-from antenati.output import ExistingPolicy, prepare_output
+from antenati.config import DownloadConfig
+from antenati.output import ExistingPolicy, existing_output_requires_decision, prepare_output
+
+
+def test_ask_is_shared_default() -> None:
+    assert DownloadConfig(url='https://example.invalid/manifest').existing_policy is ExistingPolicy.ASK
+
+
+def test_ask_detects_nonempty_output(tmp_path: Path) -> None:
+    output = tmp_path / 'archive'
+    output.mkdir()
+    (output / 'existing.jpg').write_bytes(b'existing')
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+
+    assert existing_output_requires_decision(downloader, output)
+
+
+def test_ask_does_not_prompt_for_missing_or_empty_output(tmp_path: Path) -> None:
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+    missing = tmp_path / 'missing'
+    empty = tmp_path / 'empty'
+    empty.mkdir()
+
+    assert not existing_output_requires_decision(downloader, missing)
+    assert not existing_output_requires_decision(downloader, empty)
+
+
+def test_unresolved_ask_is_rejected_by_core(tmp_path: Path) -> None:
+    downloader = Downloader('https://example.invalid/manifest', 0, None)
+
+    with pytest.raises(RuntimeError, match='must be resolved by the interface'):
+        prepare_output(downloader, tmp_path / 'archive', ExistingPolicy.ASK)
 
 
 def test_error_policy_rejects_nonempty_explicit_output(tmp_path: Path) -> None:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from antenati.cli import _planned_filename
+from antenati.downloader import DownloadItem
+
+
+def test_preview_filename_comes_from_plan_without_http_metadata() -> None:
+    item = DownloadItem(canvas={'label': 'Pag. 7'}, stem='pag-007', source_url='https://iiif.example.org/id/full/pct:100/0/default.jpg')
+    assert _planned_filename(item) == 'pag-007.jpg'
+
+
+def test_preview_normalizes_jpeg_extension() -> None:
+    item = DownloadItem(canvas={}, stem='page', source_url='https://iiif.example.org/id/full/pct:100/0/default.jpeg')
+    assert _planned_filename(item) == 'page.jpg'

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from pathlib import Path
+
+import responses
+
+from antenati import Downloader, ProgressBar
+from antenati.provenance import INDEX_FILENAME, MANIFEST_FILENAME
+from tests.conftest import GALLERY_URL, TINY_JPEG
+
+
+def _null_progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _t: None, update=lambda: None)
+
+
+def test_run_persists_manifest_and_per_image_provenance(mocked_http, tmp_path: Path) -> None:
+    downloader = Downloader(GALLERY_URL, first=0, last=1)
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    image_url = 'https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg'
+    mocked_http.add(responses.GET, image_url, body=TINY_JPEG, status=200, content_type='image/jpeg')
+
+    report = downloader.run(n_workers=1, size=0, progress=_null_progress())
+    assert report.successful
+
+    manifest_path = downloader.dirname / MANIFEST_FILENAME
+    index_path = downloader.dirname / INDEX_FILENAME
+    assert manifest_path.is_file()
+    assert index_path.is_file()
+
+    index = json.loads(index_path.read_text(encoding='utf-8'))
+    assert index['source_url'] == GALLERY_URL
+    assert index['requested_size'] == 0
+    assert len(index['images']) == 1
+    record = index['images'][0]
+    assert record['canvas_id'].endswith('/iiif-19944535/canvas/1')
+    assert record['source_url'] == image_url
+    assert record['filename'] == '0001.jpg'
+    assert record['byte_size'] == len(TINY_JPEG)
+    assert record['sha256'] == sha256(TINY_JPEG).hexdigest()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import responses
 
 from antenati import Downloader, ProgressBar
-from antenati.provenance import INDEX_FILENAME, MANIFEST_FILENAME
+from antenati.provenance import INDEX_FILENAME, MANIFEST_FILENAME, ImageRecord, verify_record
 from tests.conftest import GALLERY_URL, TINY_JPEG
 
 
@@ -39,3 +39,20 @@ def test_run_persists_manifest_and_per_image_provenance(mocked_http, tmp_path: P
     assert record['filename'] == '0001.jpg'
     assert record['byte_size'] == len(TINY_JPEG)
     assert record['sha256'] == sha256(TINY_JPEG).hexdigest()
+
+
+def test_verify_record_rejects_path_traversal_filename(tmp_path: Path) -> None:
+    outside = tmp_path / 'secret.jpg'
+    outside.write_bytes(TINY_JPEG)
+    directory = tmp_path / 'gallery'
+    directory.mkdir()
+    record = ImageRecord.create(
+        canvas_id='c1',
+        label='Pag. 1',
+        source_url='https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg',
+        filename='../secret.jpg',
+        requested_size=0,
+        byte_size=len(TINY_JPEG),
+        sha256=sha256(TINY_JPEG).hexdigest(),
+    )
+    assert verify_record(directory, record) is False

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -34,7 +34,7 @@ def test_run_persists_manifest_and_per_image_provenance(mocked_http, tmp_path: P
     assert index['requested_size'] == 0
     assert len(index['images']) == 1
     record = index['images'][0]
-    assert record['canvas_id'].endswith('/iiif-19944535/canvas/1')
+    assert record['canvas_id'].endswith('/iiif-19944535/canvas/p1')
     assert record['source_url'] == image_url
     assert record['filename'] == '0001.jpg'
     assert record['byte_size'] == len(TINY_JPEG)

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -6,7 +6,7 @@ import pytest
 import responses
 
 from antenati import ProgressBar
-from antenati.downloader import DownloadLimits, Downloader
+from antenati.downloader import Downloader, DownloadLimits
 from antenati.errors import ResourceLimitError
 from tests.conftest import GALLERY_URL, TINY_JPEG
 

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import responses
+
+from antenati import ProgressBar
+from antenati.downloader import DownloadLimits, Downloader
+from antenati.errors import ResourceLimitError
+from tests.conftest import GALLERY_URL, TINY_JPEG
+
+
+def _null_progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _t: None, update=lambda: None)
+
+
+def test_manifest_canvas_limit_fails_before_image_execution(mocked_http) -> None:
+    downloader = Downloader(GALLERY_URL, first=0, last=None, limits=DownloadLimits(max_canvases=2))
+    with pytest.raises(ResourceLimitError, match='3 canvases'):
+        downloader.load()
+
+
+def test_oversized_image_is_rejected_without_final_file(mocked_http, tmp_path: Path) -> None:
+    limits = DownloadLimits(max_image_bytes=len(TINY_JPEG) - 1)
+    downloader = Downloader(GALLERY_URL, first=0, last=1, limits=limits)
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    mocked_http.add(
+        responses.GET,
+        'https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg',
+        body=TINY_JPEG,
+        status=200,
+        content_type='image/jpeg',
+    )
+
+    report = downloader.run(n_workers=1, size=0, progress=_null_progress())
+    assert len(report.failed) == 1
+    assert 'image exceeded' in report.failed[0].reason
+    assert not (downloader.dirname / '0001.jpg').exists()
+
+
+def test_in_flight_window_scales_with_workers_without_using_gallery_size() -> None:
+    downloader = Downloader('https://example.invalid/manifest', 0, None, limits=DownloadLimits(in_flight_factor=2))
+    assert downloader._in_flight_limit(1) == 2
+    assert downloader._in_flight_limit(4) == 8

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -43,3 +43,30 @@ def test_in_flight_window_scales_with_workers_without_using_gallery_size() -> No
     downloader = Downloader('https://example.invalid/manifest', 0, None, limits=DownloadLimits(in_flight_factor=2))
     assert downloader._in_flight_limit(1) == 2
     assert downloader._in_flight_limit(4) == 8
+
+
+def test_failed_image_bytes_are_refunded_to_total_budget(mocked_http, tmp_path: Path) -> None:
+    corrupt_body = b'\x00' * 20
+    limits = DownloadLimits(max_total_bytes=len(corrupt_body))
+    downloader = Downloader(GALLERY_URL, first=0, last=2, limits=limits)
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    mocked_http.add(
+        responses.GET,
+        'https://iiif.example.org/iiif/img1/full/pct:100/0/default.jpg',
+        body=corrupt_body,
+        status=200,
+        content_type='image/jpeg',
+    )
+    mocked_http.add(
+        responses.GET,
+        'https://iiif.example.org/iiif/img2/full/pct:100/0/default.jpg',
+        body=TINY_JPEG,
+        status=200,
+        content_type='image/jpeg',
+    )
+
+    report = downloader.run(n_workers=1, size=0, progress=_null_progress())
+
+    assert len(report.failed) == 1
+    assert report.completed == 1
+    assert (downloader.dirname / '0002.jpg').read_bytes() == TINY_JPEG

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import responses
 
 from antenati import Downloader, ProgressBar
+from antenati.provenance import INDEX_FILENAME
 from tests.conftest import GALLERY_URL, TINY_JPEG
 
 
@@ -69,3 +71,33 @@ def test_resume_does_not_reuse_different_resolution(mocked_http, tmp_path: Path)
 
     assert report.skipped == 0
     assert report.completed == 1
+
+
+def test_resume_preserves_provenance_outside_requested_range(mocked_http, tmp_path: Path) -> None:
+    full = Downloader(GALLERY_URL, first=0, last=None)
+    full.check_dir(parentdir=str(tmp_path), interactive=False)
+    for n in (1, 2, 3):
+        mocked_http.add(
+            responses.GET,
+            f'https://iiif.example.org/iiif/img{n}/full/pct:100/0/default.jpg',
+            body=TINY_JPEG,
+            status=200,
+            content_type='image/jpeg',
+        )
+    report = full.run(n_workers=1, size=0, progress=_null_progress())
+    assert report.successful
+
+    narrow = Downloader(GALLERY_URL, first=1, last=2)
+    narrow.load()
+    narrow.dirname = full.dirname
+    before_calls = len(mocked_http.calls)
+
+    report = narrow.run(n_workers=1, size=0, progress=_null_progress(), resume=True)
+
+    assert report.successful
+    assert report.skipped == 1
+    assert len(mocked_http.calls) == before_calls
+
+    index = json.loads((full.dirname / INDEX_FILENAME).read_text(encoding='utf-8'))
+    filenames = {record['filename'] for record in index['images']}
+    assert filenames == {'0001.jpg', '0002.jpg', '0003.jpg'}

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import responses
+
+from antenati import Downloader, ProgressBar
+from tests.conftest import GALLERY_URL, TINY_JPEG
+
+
+def _null_progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _t: None, update=lambda: None)
+
+
+def _image_url(size: int = 0) -> str:
+    size_part = f'!{size},{size}' if size > 0 else 'pct:100'
+    return f'https://iiif.example.org/iiif/img1/full/{size_part}/0/default.jpg'
+
+
+def _first_run(mocked_http, tmp_path: Path, size: int = 0) -> Downloader:
+    downloader = Downloader(GALLERY_URL, first=0, last=1)
+    downloader.check_dir(parentdir=str(tmp_path), interactive=False)
+    mocked_http.add(responses.GET, _image_url(size), body=TINY_JPEG, status=200, content_type='image/jpeg')
+    report = downloader.run(n_workers=1, size=size, progress=_null_progress())
+    assert report.successful
+    return downloader
+
+
+def test_resume_skips_hash_verified_existing_file(mocked_http, tmp_path: Path) -> None:
+    first = _first_run(mocked_http, tmp_path)
+    resumed = Downloader(GALLERY_URL, first=0, last=1)
+    resumed.load()
+    resumed.dirname = first.dirname
+
+    before_calls = len(mocked_http.calls)
+    report = resumed.run(n_workers=1, size=0, progress=_null_progress(), resume=True)
+
+    assert report.successful
+    assert report.skipped == 1
+    assert report.completed == 0
+    assert len(mocked_http.calls) == before_calls
+
+
+def test_resume_redownloads_corrupt_indexed_file(mocked_http, tmp_path: Path) -> None:
+    first = _first_run(mocked_http, tmp_path)
+    image_path = first.dirname / '0001.jpg'
+    image_path.write_bytes(b'corrupt')
+
+    resumed = Downloader(GALLERY_URL, first=0, last=1)
+    resumed.load()
+    resumed.dirname = first.dirname
+    mocked_http.add(responses.GET, _image_url(), body=TINY_JPEG, status=200, content_type='image/jpeg')
+    report = resumed.run(n_workers=1, size=0, progress=_null_progress(), resume=True)
+
+    assert report.successful
+    assert report.skipped == 0
+    assert report.completed == 1
+    assert image_path.read_bytes() == TINY_JPEG
+
+
+def test_resume_does_not_reuse_different_resolution(mocked_http, tmp_path: Path) -> None:
+    first = _first_run(mocked_http, tmp_path, size=0)
+    resumed = Downloader(GALLERY_URL, first=0, last=1)
+    resumed.load()
+    resumed.dirname = first.dirname
+    mocked_http.add(responses.GET, _image_url(200), body=TINY_JPEG, status=200, content_type='image/jpeg')
+
+    report = resumed.run(n_workers=1, size=200, progress=_null_progress(), resume=True)
+
+    assert report.skipped == 0
+    assert report.completed == 1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,10 +34,10 @@ def test_programmatic_run_rejects_invalid_workers_before_network() -> None:
     with responses.RequestsMock() as mocked:
         with pytest.raises(ValidationError, match='n_workers'):
             downloader.run(n_workers=0, size=0, progress=_null_progress())
-        assert mocked.calls == []
+        assert len(mocked.calls) == 0
 
 
 def test_gui_params_use_same_core_validation() -> None:
-    params = DownloadParams(url='https://example.invalid/manifest', parent_dir='.', size=-1, first=0, last=None)
+    params = DownloadParams(url='https://example.invalid/manifest', output_dir='.', size=-1, first=0, last=None)
     with pytest.raises(ValidationError, match='size'):
-        params.validate()
+        params.validate(require_output=True)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+import responses
+
+from antenati import Downloader, ProgressBar
+from antenati.errors import ValidationError
+from antenati.gui.worker import DownloadParams
+from antenati.validation import DownloadOptions
+
+
+def _null_progress() -> ProgressBar:
+    return ProgressBar(set_total=lambda _t: None, update=lambda: None)
+
+
+@pytest.mark.parametrize(
+    'options',
+    [
+        DownloadOptions(first=-1),
+        DownloadOptions(first=2, last=2),
+        DownloadOptions(first=3, last=2),
+        DownloadOptions(size=-1),
+        DownloadOptions(n_workers=0),
+        DownloadOptions(n_workers=65),
+    ],
+)
+def test_shared_options_reject_invalid_values(options: DownloadOptions) -> None:
+    with pytest.raises(ValidationError):
+        options.validate()
+
+
+def test_programmatic_run_rejects_invalid_workers_before_network() -> None:
+    downloader = Downloader('https://antenati.cultura.gov.it/ark:/12657/an_ua1/gallery', 0, None)
+    with responses.RequestsMock() as mocked:
+        with pytest.raises(ValidationError, match='n_workers'):
+            downloader.run(n_workers=0, size=0, progress=_null_progress())
+        assert mocked.calls == []
+
+
+def test_gui_params_use_same_core_validation() -> None:
+    params = DownloadParams(url='https://example.invalid/manifest', parent_dir='.', size=-1, first=0, last=None)
+    with pytest.raises(ValidationError, match='size'):
+        params.validate()


### PR DESCRIPTION
## Summary

This PR is the v7.0 architecture and integrity release. It turns the downloader into an explicitly planned, verifiable and resumable workflow while keeping Portale Antenati as the supported source profile.

### Architecture and result model
- Separate configuration, source loading, planning and execution; constructing `Downloader` no longer performs network I/O (#67).
- Introduce a shared structured `DownloadReport` with expected, attempted, completed, skipped, failed, cancelled and byte-count state (#60).

### Stable files and provenance
- Zero-pad numeric page labels using the complete gallery size, keeping filenames stable across subsets and execution order (#73).
- Persist `.antenati-manifest.json` and `.antenati-index.json` with canvas/source mapping, requested resolution, byte size, SHA-256 and timestamp (#61).
- Add verified resume: existing images are reused only when provenance, source/resolution, size and hash still match; stale/corrupt files are redownloaded (#59).

### Integrity and resource control
- Validate supported image MIME/signature data before atomically committing final files; reject HTML/text, corrupt data and MIME/signature mismatches (#47).
- Stream image responses, bound in-flight futures and enforce explicit metadata/image/canvas/total-byte ceilings (#50).
- Centralize range/size/worker and response-metadata validation across programmatic, CLI and GUI paths (#52).

### User-facing workflow
- Add exact output selection and explicit `error`, `overwrite`, `skip` and `resume` existing-output policies to CLI and GUI (#62).
- Add CLI `--dry-run` preview of the exact download plan without image writes (#63).
- Share one configuration model between CLI and GUI and expose worker count/descriptive filenames consistently (#64).

### Tests and documentation
- Strengthen the offline correctness suite around cancellation side effects, collisions/padding, integrity, reports, provenance, resume, output policies, resource limits and shared config (#66).
- Rewrite README guarantees and terminology around the actual single-gallery/register scope, Antenati-specific IIIF support, integrity guarantees, WAF limitations and CLI/GUI capability parity; add the v7.0 changelog section (#68).

## Validation

Final CI run `34039747571` is green:
- Ruff check
- Ruff format check
- mypy
- offline tests + CLI smoke tests on Python 3.10, 3.11, 3.12, 3.13 and 3.14 across Ubuntu 24.04, macOS 14 and Windows 2022 (15 combinations)

## Scope deliberately left for later

This PR does not implement the Antenati URL trust policy (#48), broader generic IIIF compatibility (#65), or controlled batch mode (#70).

Closes #47
Closes #50
Closes #52
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #66
Closes #67
Closes #68
Closes #73